### PR TITLE
Prepare release of mapper script on github pages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: C
+before_script: chmod +x travis.sh
+script: ./travis.sh

--- a/mudlet-mapper.xml
+++ b/mudlet-mapper.xml
@@ -4439,7 +4439,7 @@ mmp.speedWalkPath = mmp.speedWalkPath or {}
 mmp.speedWalkDir = mmp.speedWalkDir or {}
 
 
-local newversion = &quot;16.3.1&quot;
+local newversion = &quot;developer&quot;
 if mmp.version and mmp.version ~= newversion then
   if not mmp.game then mmp.echo(&quot;Mapper script updated - Thanks! I don't know what game are you connected to, though - so please reconnect, if you could.&quot;)
   else mmp.echo(&quot;Mapper script updated - thanks! You don't need to restart.&quot;) end

--- a/travis.sh
+++ b/travis.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+if [ "$TRAVIS_BRANCH" != "master" -o "$TRAVIS_PULL_REQUEST" != "false" ]; then
+  echo "Not on master, aborting"
+  exit 0
+fi
+
+if [ "$TRAVIS_REPO_SLUG" != "IRE-Mudlet-Mapping/ire-mapping-script" ]; then
+  echo "Not on main repo, aborting"
+  exit 0
+fi
+
+mainDirectory=`pwd`
+
+cd ..
+git clone --quiet --branch=gh-pages "https://IREMappingBot:${GH_TOKEN}@github.com/IRE-Mudlet-Mapping/ire-mapping-script.git" gh-pages 
+
+cd gh-pages/downloads
+cp "$mainDirectory/mudlet-mapper.xml" .
+
+datePart=$(date +"%y.%-m")
+lastDatePart=$(echo "$(cat version 3> /dev/null)" | grep -o "^[0-9]*\.[0-9]*")
+if [ "$lastDatePart" = "$datePart" ]; then
+  versionPart=$(($(cat version | grep -o "[0-9]*$") + 1))
+else
+  versionPart=1
+fi
+version="$datePart.$versionPart"
+sed -rbe 's/local newversion = &quot;developer&quot;/local newversion = \&quot;'$version'\&quot;/g' mudlet-mapper.xml > mudlet-mapper.xml.tmp && mv mudlet-mapper.xml.tmp mudlet-mapper.xml
+echo "$version" > version
+
+git config user.email "IREMappingBot@travis-ci.org"
+git config user.name "IREMappingBot"
+
+git commit -m"Release new version" .
+
+git push --quiet


### PR DESCRIPTION
This commit contains the travis configuration and script file that can be used to upload the mapper script to GitHub pages via travis.
The upload will abort if the commit was not on master and not on the main repository.

I will set up a bot account a little later so the release gets done on an independent account.