### PR TITLE
Fix typo in register_achaeas_envdata

### DIFF
--- a/mudlet-mapper.xml
+++ b/mudlet-mapper.xml
@@ -7563,7 +7563,7 @@ end</script>
   }
 
   mmp.waterenvs = {}
-  local waterids = { &quot;Freshwater&quot;, &quot;Ocean&quot;, &quot;River&quot;, &quot;Deep Ocean&quot;, &quot;Water&quot;, &quot;Reef&quot;, &quot;Ocean floor&quot;, &quot;Vast Oceran&quot; }
+  local waterids = { &quot;Freshwater&quot;, &quot;Ocean&quot;, &quot;River&quot;, &quot;Deep Ocean&quot;, &quot;Water&quot;, &quot;Reef&quot;, &quot;Ocean floor&quot;, &quot;Vast Ocean&quot; }
   for i = 1, #waterids do mmp.waterenvs[mmp.envids[waterids[i]]] = true end
 
   mmp.envidsr = {};


### PR DESCRIPTION
This fixes a simple typo that was causing the register_achaeas_envdata function to fail due to a nil table index, leaving mmp.envdirsr empty since the function bails.