### PR TITLE
Allow duanathar on continent change

### DIFF
--- a/mudlet-mapper.xml
+++ b/mudlet-mapper.xml
@@ -7569,6 +7569,7 @@ end</script>
 function mmapper_achaea_went_outside()
   if not mmp.autowalking or not (mmp.settings.duanathar or mmp.settings.duanatharan or mmp.settings.duantahar) or mmp.game ~= &quot;achaea&quot; or
     (mmp.currentroom == mmp.speedWalkPath[#mmp.speedWalkPath]) or
+    table.contains(gmcp.Room.Info.details, &quot;indoors&quot;) or
     not mmp.oncontinent(getRoomArea(mmp.currentroom), &quot;Prime&quot;) then return end
 
   -- repath, maybe that'll allow us to use wings now.

--- a/mudlet-mapper.xml
+++ b/mudlet-mapper.xml
@@ -5073,6 +5073,9 @@ function speedwalking( event, num )
       mmp.inside = true
       raiseEvent(&quot;mmapper went inside&quot;)
     end
+    if #table.n_union(mmp.getareacontinents(getRoomArea(mmp.previousroom)), mmp.getareacontinents(getRoomArea(num))) ~= #mmp.getareacontinents(getRoomArea(num)) then
+      raiseEvent(&quot;mmapper changed continent&quot;)
+    end
     -- the event could cancel speedwalking - in this case quit
     if mmp.ignore_speedwalking then
       mmp.ignore_speedwalking = nil
@@ -7611,6 +7614,7 @@ function mmapper_achaea_went_outside()
 end</script>
                         <eventHandlerList>
                             <string>mmapper went outside</string>
+                            <string>mmapper changed continent</string>
                         </eventHandlerList>
                     </Script>
                 </Script>


### PR DESCRIPTION
- Dependent on part of #20 
- Will recalculate the path with duanathar/duanatharan room linked when changing the continent. That allows us to use those rooms for shortcuts.
