### PR TITLE
update mudlet-mapper.xml

### DIFF
--- a/mudlet-mapper.xml
+++ b/mudlet-mapper.xml
@@ -4446,7 +4446,7 @@ end
 mmp.version = newversion
 
 function mmp.startup()
-  if not mmp.firstRun then
+  if mmp.firstRun == false then
     return
   end
 


### PR DESCRIPTION
I think this fixes an issue whereby mmp.startup() checks for **if not mmp.firstRun** when trying to initialise. I changed to **if mmp.firstRun == false** as a check, since an unitialised variable has the **nil** value and matches true against **not** logic checks.

This seems to fix the issue with my script on initialisation in Mudlet 3.00 Epsilon that I know some others were having too.