### PR TITLE
Added the actual map open event that's used

### DIFF
--- a/mudlet-mapper.xml
+++ b/mudlet-mapper.xml
@@ -8768,7 +8768,7 @@ end</script>
                         <string>sys2DMapLoad</string>
                         <string>sys3DMapLoad</string>
                         <string>sysMapDownloadEvent</string>
-			<string>mapOpenEvent</string>
+                        <string>mapOpenEvent</string>
                     </eventHandlerList>
                 </Script>
             </Script>

--- a/mudlet-mapper.xml
+++ b/mudlet-mapper.xml
@@ -8768,6 +8768,7 @@ end</script>
                         <string>sys2DMapLoad</string>
                         <string>sys3DMapLoad</string>
                         <string>sysMapDownloadEvent</string>
+			<string>mapOpenEvent</string>
                     </eventHandlerList>
                 </Script>
             </Script>


### PR DESCRIPTION
Not sure what happened, but ``sysMapLoad``, ``sys2DMapLoad``, and ``sys3DMapLoad`` aren't used by Mudlet. Not sure why I added them. ``mapOpenEvent`` is, see http://wiki.mudlet.org/w/Manual:Event_Engine#mapOpenEvent.

Without this fix, 'rf room' will show 'nil' unless you've also downloaded a map in the same session (because ``sysMapDownloadEvent`` saves it).