### PR TITLE
Update mudlet-mapper.xml

### DIFF
--- a/mudlet-mapper.xml
+++ b/mudlet-mapper.xml
@@ -8739,7 +8739,7 @@ end</script>
                         </eventHandlerList>
                     </Script>
                 </Script>
-                <Script isActive="yes" isFolder="no">
+                <Script isActive="no" isFolder="no">
                     <name>mmp_see_dl_errors</name>
                     <packageName></packageName>
                     <script>-- this should be off by default


### PR DESCRIPTION
This needs to be disabled by default, it's a debug echo. With it on, people see randoms stuff like:

```lua
{
  "sysDownloadError",
  "Host ire-mudlet-mapping.github.io not found",
  "C:\\Users\\girlh\\.config\\mudlet\\profiles\\Priest/map downloads/MD5"
}
{
  "sysDownloadError",
  "Host ire-mudlet-mapping.github.io not found",
  "C:\\Users\\girlh\\.config\\mudlet\\profiles\\Priest/map downloads/mapper"
}
```

Then freak out and send me emails.