### PR TITLE
Setting pathcache to clear when option is changed

### DIFF
--- a/mudlet-mapper.xml
+++ b/mudlet-mapper.xml
@@ -4440,6 +4440,7 @@ function createOptionsTable(defaultTable)
 			local opt = rawget(self[index], option)
 			if opt.onChange  and not silent then opt.onChange(option, value) end
 		end
+		if mmp and mmp.clearpathcache then mmp.clearpathcache() end
 	end
 
 


### PR DESCRIPTION
It's confusing, frustrating and sometimes deadly when people change their map configs and then try to move out from the same location, or a location they've pathed from before. Simple fix. Probably better ways to do it.