### PR TITLE
Changed room mark alias to take one argument

### DIFF
--- a/mudlet-mapper.xml
+++ b/mudlet-mapper.xml
@@ -4300,7 +4300,10 @@ if tmp ~= &quot;&quot; then
 end
 
 local location, markname
-if tonumber(matches[2]) then
+if not matches[3] then
+  markname = matches[2]
+  location = gmcp.Room.Info.num
+elseif tonumber(matches[2]) then
   location = matches[2]; markname = matches[3]
 else
   location = matches[3]; markname = matches[2]
@@ -4322,7 +4325,7 @@ setRoomUserData(1, &quot;gotoMapping&quot;, tmp2)
 mmp.echo(string.format(&quot;Room mark for '%s' set to room %s.&quot;, markname, location))</script>
                 <command></command>
                 <packageName></packageName>
-                <regex>^room mark (\w+) (\w+)$</regex>
+                <regex>^room mark (\w+)(?: (\w+))?$</regex>
             </Alias>
             <Alias isActive="yes" isFolder="no">
                 <name>Remove Room Mark</name>

--- a/mudlet-mapper.xml
+++ b/mudlet-mapper.xml
@@ -4302,7 +4302,7 @@ end
 local location, markname
 if not matches[3] then
   markname = matches[2]
-  location = gmcp.Room.Info.num
+  location = mmp.currentroom
 elseif tonumber(matches[2]) then
   location = matches[2]; markname = matches[3]
 else


### PR DESCRIPTION
Changed it you can give room mark a single argument.
If you do this, it'll use it as the mark name, and mark your current room.
Original behavior with two arguments is unchanged.