### PR TITLE
Changed gotoArea to not run if already within the area.

### DIFF
--- a/mudlet-mapper.xml
+++ b/mudlet-mapper.xml
@@ -5054,6 +5054,10 @@ function mmp.gotoArea (where, number, dashtype, exact)
 
   local areaid, msg, multiples = mmp.findAreaID(where, exact)
   if areaid then
+    if areaid==getRoomArea(mmp.currentroom) then
+      mmp.echo(&quot;We're already in &quot;..msg..&quot;!&quot;)
+      return
+    end
      possibleRooms = mmp.getAreaBorders(areaid)
 
   elseif not areaid and #multiples &gt; 0 then


### PR DESCRIPTION
Small change to gotoArea. If used within an area, it now stops and pops a message telling you that you're in that area, similar to how gotoRoom fails if you're in the room. Its previous behavior was to walk to the closest 'edge' it could find for that area.