### PR TITLE
Preparations for cron CI runs

### DIFF
--- a/travis.sh
+++ b/travis.sh
@@ -10,6 +10,16 @@ if [ "$TRAVIS_REPO_SLUG" != "IRE-Mudlet-Mapping/ire-mapping-script" ]; then
   exit 0
 fi
 
+wget -O "/usr/tmp/mudlet-mapper.xml" http://ire-mudlet-mapping.github.io/ire-mapping-script/downloads/mudlet-mapper.xml
+
+currentScriptSha1=$(grep -v "local newversion = " /usr/tmp/mudlet-mapper.xml | sha1sum | cut -d " " -f1)
+newScriptSha1=$(grep -v "local newversion = " mudlet-mapper.xml | sha1sum | cut -d " " -f1)
+
+if [ "${currentScriptSha1}" = "${newScriptSha1}" ]; then
+  echo "No change in the script, aborting"
+  exit 0
+fi
+
 mainDirectory=`pwd`
 
 cd ..


### PR DESCRIPTION
This commit prepares for the ability to run CI jobs on a cron instead of
on every PR. That way we won't publish a new version with every merged
PR, but have one release on a regular schedule.

Te way it works is that it compares a checksum of the currently released
script with the script in the repository (leaving out the version line).
If those differ, a new release is created.