### PR TITLE
Adding universe tarot support + small change to mmp.tempSpecialExit

### DIFF
--- a/mudlet-mapper.xml
+++ b/mudlet-mapper.xml
@@ -4857,6 +4857,7 @@ function mmp.startup()
   private_settings[&quot;duanatharan&quot;]   = createOption(false, mmp.setDuanatharan, { &quot;boolean&quot; }, &quot;Use Atavian Wings in Achaea?&quot;)
   private_settings[&quot;duanathar&quot;]     = createOption(false, mmp.setDuanathar, { &quot;boolean&quot; }, &quot;Use Eagle Wings in Achaea?&quot;)
   private_settings[&quot;shackle&quot;]       = createOption(false, mmp.changeBoolFunc, { &quot;boolean&quot; }, &quot;Take off shackle?&quot;)
+  private_settings[&quot;universe&quot;]      = createOption(false, mmp.setUniverse, {&quot;boolean&quot; }, &quot;Use Universe Tarot in Achaea?&quot;)
 
 --Lusternia bixes
   private_settings[&quot;torus&quot;]         = createOption(false, mmp.setTorus, { &quot;boolean&quot; }, &quot;Make use of your Torus in Lusternia?&quot;)
@@ -4975,6 +4976,7 @@ wheel={lusternia=true},
 mantle={lusternia=true},
 key={lusternia=true},
 winglanguage={achaea=true,}
+universe={achaea=true},
 }
 function mmp.rebuildOptionsTable(_,game)
 	game=game:lower()
@@ -5584,9 +5586,12 @@ end</script>
                     <packageName></packageName>
                     <script>local exitsCreated = exitsCreated or {}
 
-function mmp.tempSpecialExit(destination, command)
+function mmp.tempSpecialExit(destination, command, weight)
   table.insert(exitsCreated, destination)
   addSpecialExit(mmp.currentroom, destination, command)
+	if weight then
+	  setExitWeight(mmp.currentroom,command,weight)
+	end
 end
 
 function mmp.removeWings()
@@ -5669,6 +5674,40 @@ function mmp.addWingsAchaea()
       -- western isles
     elseif mmp.oncontinent(getRoomArea(mmp.currentroom), &quot;Western_Isles&quot;) then
       mmp.tempSpecialExit(54632, &quot;Shake Harness&quot;)
+    end
+  end
+  --universe tarot
+  if
+    mmp.settings.universe and
+    mmp.oncontinent(getRoomArea(mmp.currentroom), &quot;Main&quot;)
+  then
+    local tarotLocations =
+      {
+        azdun = 1772,
+        blackrock = 10573,
+        bitterfork = 25093,
+        genji = 10091,
+        manusha = 8730,
+        newthera = 20386,
+        caerwitrin = 17678,
+        shastaan = 2855,
+        mannaseh = 1745,
+        manara = 9124,
+        brasslantern = 30383,
+        mhojave = 39103,
+        thraasi = 35703,
+        newhope = 25581,
+      }
+    for village, roomnum in pairs(tarotLocations) do
+      mmp.tempSpecialExit(
+        roomnum,
+        [=[script:
+        mmp.customwalkdelay(4.5)
+        send(&quot;fling universe at ground&quot;,false)
+        tempTimer(4,[[send(&quot;touch ]=] .. village .. [=[&quot;,false)]])
+        ]=],
+        10
+      )
     end
   end
   --clears the path cache so it calculates a new route.
@@ -6787,6 +6826,14 @@ function mmp.setDuantahar()
 
   if mmp.settings.duantahar then mmp.echo(&quot;Okay, will see about using Chenubian wings (duanathar, duanatharan, and duantahar) when you goto somewhere while outside!&quot;)
   else mmp.echo(&quot;Won't use Chenubian wings anymore.&quot;) end
+end
+
+function mmp.setUniverse()
+  mmp.clearpathcache()
+	
+	if mmp.settings.universe then mmp.echo(&quot;Okay, will see about using the Universe tarot whenever it's faster.&quot;)
+	else mmp.echo(&quot;Won't use Universe tarot anymore.&quot;) end
+
 end
 
 function mmp.chageMapSource()

--- a/mudlet-mapper.xml
+++ b/mudlet-mapper.xml
@@ -4850,51 +4850,51 @@ function mmp.startup()
 
 --Achaea wings and things
   private_settings[&quot;winglanguage&quot;]  = createOption(&quot;&quot;, mmp.setWingsLanguage, { &quot;string&quot; }, &quot;Speak non-default language for wings:&quot;)
-  private_settings[&quot;pebble&quot;]        = createOption(false, mmp.lockPebble, { &quot;boolean&quot; }, &quot;Make use of your enchanted pebble in Achaea?&quot;)
+  private_settings[&quot;pebble&quot;]        = createOption(false, mmp.lockPebble, { &quot;boolean&quot; }, &quot;Make use of your enchanted pebble?&quot;)
   private_settings[&quot;removewings&quot;]   = createOption(true, mmp.setWingsRemoval, { &quot;boolean&quot; }, &quot;Remove Wings after using them?&quot;)
-  private_settings[&quot;harness&quot;]				= createOption(false, mmp.setHarness, { &quot;boolean&quot; }, &quot;Use Stratospheric Harness in Achaea?&quot;) --PapaGuacamole
-  private_settings[&quot;duantahar&quot;]     = createOption(false, mmp.setDuantahar, { &quot;boolean&quot; }, &quot;Use Chenubian Wings in Achaea?&quot;)
-  private_settings[&quot;duanatharan&quot;]   = createOption(false, mmp.setDuanatharan, { &quot;boolean&quot; }, &quot;Use Atavian Wings in Achaea?&quot;)
-  private_settings[&quot;duanathar&quot;]     = createOption(false, mmp.setDuanathar, { &quot;boolean&quot; }, &quot;Use Eagle Wings in Achaea?&quot;)
+  private_settings[&quot;harness&quot;]				= createOption(false, mmp.setHarness, { &quot;boolean&quot; }, &quot;Use Stratospheric Harness?&quot;) --PapaGuacamole
+  private_settings[&quot;duantahar&quot;]     = createOption(false, mmp.setDuantahar, { &quot;boolean&quot; }, &quot;Use Chenubian Wings?&quot;)
+  private_settings[&quot;duanatharan&quot;]   = createOption(false, mmp.setDuanatharan, { &quot;boolean&quot; }, &quot;Use Atavian Wings?&quot;)
+  private_settings[&quot;duanathar&quot;]     = createOption(false, mmp.setDuanathar, { &quot;boolean&quot; }, &quot;Use Eagle Wings?&quot;)
   private_settings[&quot;shackle&quot;]       = createOption(false, mmp.changeBoolFunc, { &quot;boolean&quot; }, &quot;Take off shackle?&quot;)
-  private_settings[&quot;universe&quot;]      = createOption(false, mmp.setUniverse, {&quot;boolean&quot; }, &quot;Use Universe Tarot in Achaea?&quot;)
+  private_settings[&quot;universe&quot;]      = createOption(false, mmp.setUniverse, {&quot;boolean&quot; }, &quot;Use Universe Tarot?&quot;)
 
 --Lusternia bixes
-  private_settings[&quot;torus&quot;]         = createOption(false, mmp.setTorus, { &quot;boolean&quot; }, &quot;Make use of your Torus in Lusternia?&quot;)
-  private_settings[&quot;prism&quot;]         = createOption(false, mmp.setPrism, {&quot;boolean&quot;}, &quot;Make use of your transplanar prism in Lusternia&quot;)
-  private_settings[&quot;cubix&quot;]         = createOption(false, mmp.setCubix, { &quot;boolean&quot; }, &quot;Make use of your Cubix in Lusternia?&quot;)
-  private_settings[&quot;medallion&quot;]     = createOption(false, mmp.setMedallion, { &quot;boolean&quot; }, &quot;Make use of your Medallion in Lusternia?&quot;)
+  private_settings[&quot;torus&quot;]         = createOption(false, mmp.setTorus, { &quot;boolean&quot; }, &quot;Make use of your Torus?&quot;)
+  private_settings[&quot;prism&quot;]         = createOption(false, mmp.setPrism, {&quot;boolean&quot;}, &quot;Make use of your transplanar prism?&quot;)
+  private_settings[&quot;cubix&quot;]         = createOption(false, mmp.setCubix, { &quot;boolean&quot; }, &quot;Make use of your Cubix?&quot;)
+  private_settings[&quot;medallion&quot;]     = createOption(false, mmp.setMedallion, { &quot;boolean&quot; }, &quot;Make use of your Medallion?&quot;)
 
 --Lusternia Bubblixes
-  private_settings[&quot;tibia&quot;]         = createOption(false, mmp.setTibia, { &quot;boolean&quot; }, &quot;Make use of your Tibia in Lusternia?&quot;)
-  private_settings[&quot;mud&quot;]           = createOption(false, mmp.setMud, { &quot;boolean&quot; }, &quot;Make use of your Mud in Lusternia?&quot;)
-  private_settings[&quot;cookie&quot;]        = createOption(false, mmp.setCookie, { &quot;boolean&quot; }, &quot;Make use of your Cookie in Lusternia?&quot;)
-  private_settings[&quot;icicle&quot;]        = createOption(false, mmp.setIcicle, { &quot;boolean&quot; }, &quot;Make use of your Icicle in Lusternia?&quot;)
-  private_settings[&quot;screwdriver&quot;]   = createOption(false, mmp.setScrewdriver, { &quot;boolean&quot; }, &quot;Make use of your Screwdriver in Lusternia?&quot;)
-  private_settings[&quot;snowglobe&quot;]     = createOption(false, mmp.setSnowglobe, { &quot;boolean&quot; }, &quot;Make use of your Snowglobe in Lusternia?&quot;)
-  private_settings[&quot;head&quot;]          = createOption(false, mmp.setHead, { &quot;boolean&quot; }, &quot;Make use of your Doll's Head in Lusternia?&quot;)
-  private_settings[&quot;wheel&quot;]         = createOption(false, mmp.setWheel, { &quot;boolean&quot; }, &quot;Make use of your Wheel in Lusternia?&quot;)
+  private_settings[&quot;tibia&quot;]         = createOption(false, mmp.setTibia, { &quot;boolean&quot; }, &quot;Make use of your Tibia?&quot;)
+  private_settings[&quot;mud&quot;]           = createOption(false, mmp.setMud, { &quot;boolean&quot; }, &quot;Make use of your Mud?&quot;)
+  private_settings[&quot;cookie&quot;]        = createOption(false, mmp.setCookie, { &quot;boolean&quot; }, &quot;Make use of your Cookie?&quot;)
+  private_settings[&quot;icicle&quot;]        = createOption(false, mmp.setIcicle, { &quot;boolean&quot; }, &quot;Make use of your Icicle?&quot;)
+  private_settings[&quot;screwdriver&quot;]   = createOption(false, mmp.setScrewdriver, { &quot;boolean&quot; }, &quot;Make use of your Screwdriver?&quot;)
+  private_settings[&quot;snowglobe&quot;]     = createOption(false, mmp.setSnowglobe, { &quot;boolean&quot; }, &quot;Make use of your Snowglobe?&quot;)
+  private_settings[&quot;head&quot;]          = createOption(false, mmp.setHead, { &quot;boolean&quot; }, &quot;Make use of your Doll's Head?&quot;)
+  private_settings[&quot;wheel&quot;]         = createOption(false, mmp.setWheel, { &quot;boolean&quot; }, &quot;Make use of your Quartz Wheel?&quot;)
 
 --Lusternia Curio collections
-  private_settings[&quot;bonecurio&quot;]     = createOption(false, mmp.setBonecurio, { &quot;boolean&quot; }, &quot;Make use of your Bone curios in Lusternia?&quot;)
-  private_settings[&quot;facecurio&quot;]     = createOption(false, mmp.setFacecurio, { &quot;boolean&quot; }, &quot;Make use of your Face curios in Lusternia?&quot;)
-  private_settings[&quot;feathercurio&quot;]  = createOption(false, mmp.setFeathercurio, { &quot;boolean&quot; }, &quot;Make use of your Feather curios in Lusternia?&quot;)
-  private_settings[&quot;figurecurio&quot;]   = createOption(false, mmp.setFigurecurio, { &quot;boolean&quot; }, &quot;Make use of your Figure curios in Lusternia?&quot;)
-  private_settings[&quot;flowercurio&quot;]   = createOption(false, mmp.setFlowercurio, { &quot;boolean&quot; }, &quot;Make use of your Flower curios in Lusternia?&quot;)
-  private_settings[&quot;fluttercurio&quot;]  = createOption(false, mmp.setFluttercurio, { &quot;boolean&quot; }, &quot;Make use of your Flutter curios in Lusternia?&quot;)
-  private_settings[&quot;toolcurio&quot;]     = createOption(false, mmp.setToolcurio, { &quot;boolean&quot; }, &quot;Make use of your Tool curios in Lusternia?&quot;)
-  private_settings[&quot;vernalcurio&quot;]   = createOption(false, mmp.setVernalcurio, { &quot;boolean&quot; }, &quot;Make use of your Vernal curios in Lusternia?&quot;)
-  private_settings[&quot;utensilcurio&quot;]  = createOption(false, mmp.setUtensilcurio, { &quot;boolean&quot; }, &quot;Make use of your Utensil curios in Lusternia?&quot;)
-  private_settings[&quot;toycurio&quot;]      = createOption(false, mmp.setToycurio, { &quot;boolean&quot; }, &quot;Make use of your Toy curios in Lusternia?&quot;)
-  private_settings[&quot;soullesscurio&quot;] = createOption(false, mmp.setSoullesscurio, { &quot;boolean&quot; }, &quot;Make use of your Soulless curios in Lusternia?&quot;)
+  private_settings[&quot;bonecurio&quot;]     = createOption(false, mmp.setBonecurio, { &quot;boolean&quot; }, &quot;Make use of your Bone curios?&quot;)
+  private_settings[&quot;facecurio&quot;]     = createOption(false, mmp.setFacecurio, { &quot;boolean&quot; }, &quot;Make use of your Face curios?&quot;)
+  private_settings[&quot;feathercurio&quot;]  = createOption(false, mmp.setFeathercurio, { &quot;boolean&quot; }, &quot;Make use of your Feather curios?&quot;)
+  private_settings[&quot;figurecurio&quot;]   = createOption(false, mmp.setFigurecurio, { &quot;boolean&quot; }, &quot;Make use of your Figure curios?&quot;)
+  private_settings[&quot;flowercurio&quot;]   = createOption(false, mmp.setFlowercurio, { &quot;boolean&quot; }, &quot;Make use of your Flower curios?&quot;)
+  private_settings[&quot;fluttercurio&quot;]  = createOption(false, mmp.setFluttercurio, { &quot;boolean&quot; }, &quot;Make use of your Flutter curios?&quot;)
+  private_settings[&quot;toolcurio&quot;]     = createOption(false, mmp.setToolcurio, { &quot;boolean&quot; }, &quot;Make use of your Tool curios]?&quot;)
+  private_settings[&quot;vernalcurio&quot;]   = createOption(false, mmp.setVernalcurio, { &quot;boolean&quot; }, &quot;Make use of your Vernal curios?&quot;)
+  private_settings[&quot;utensilcurio&quot;]  = createOption(false, mmp.setUtensilcurio, { &quot;boolean&quot; }, &quot;Make use of your Utensil curios?&quot;)
+  private_settings[&quot;toycurio&quot;]      = createOption(false, mmp.setToycurio, { &quot;boolean&quot; }, &quot;Make use of your Toy curios?&quot;)
+  private_settings[&quot;soullesscurio&quot;] = createOption(false, mmp.setSoullesscurio, { &quot;boolean&quot; }, &quot;Make use of your Soulless curios?&quot;)
 
 --Lusternia epic
-  private_settings[&quot;fingerblade&quot;]   = createOption(false, mmp.setFingerblade, { &quot;boolean&quot; }, &quot;Make use of your Fingerblade in Lusternia?&quot;)
-  private_settings[&quot;blossom&quot;]       = createOption(false, mmp.setBlossom, { &quot;boolean&quot; }, &quot;Make use of your Flame of dae'Seren in Lusternia?&quot;)
-  private_settings[&quot;belt&quot;]          = createOption(false, mmp.setBelt, { &quot;boolean&quot; }, &quot;Make use of your Belt in Lusternia?&quot;)
-  private_settings[&quot;mandala&quot;]       = createOption(false, mmp.setMandala, { &quot;boolean&quot; }, &quot;Make use of your Mandala in Lusternia?&quot;)
-  private_settings[&quot;mantle&quot;]        = createOption(false, mmp.setMantle, { &quot;boolean&quot; }, &quot;Make use of your Mantle in Lusternia?&quot;)
-  private_settings[&quot;key&quot;]           = createOption(false, mmp.setKey, { &quot;boolean&quot; }, &quot;Make use of your Key in Lusternia?&quot;)
+  private_settings[&quot;fingerblade&quot;]   = createOption(false, mmp.setFingerblade, { &quot;boolean&quot; }, &quot;Make use of your Fingerblade?&quot;)
+  private_settings[&quot;blossom&quot;]       = createOption(false, mmp.setBlossom, { &quot;boolean&quot; }, &quot;Make use of your Flame of dae'Seren?&quot;)
+  private_settings[&quot;belt&quot;]          = createOption(false, mmp.setBelt, { &quot;boolean&quot; }, &quot;Make use of your Belt?&quot;)
+  private_settings[&quot;mandala&quot;]       = createOption(false, mmp.setMandala, { &quot;boolean&quot; }, &quot;Make use of your Mandala?&quot;)
+  private_settings[&quot;mantle&quot;]        = createOption(false, mmp.setMantle, { &quot;boolean&quot; }, &quot;Make use of your Mantle?&quot;)
+  private_settings[&quot;key&quot;]           = createOption(false, mmp.setKey, { &quot;boolean&quot; }, &quot;Make use of your Key?&quot;)
 
 --misc
   private_settings[&quot;caravan&quot;]       = createOption(false, mmp.changeBoolFunc,{ &quot;boolean&quot; }, &quot;Walk caravans?&quot;)
@@ -4975,7 +4975,7 @@ soullesscurio={lusternia=true},
 wheel={lusternia=true},
 mantle={lusternia=true},
 key={lusternia=true},
-winglanguage={achaea=true,}
+winglanguage={achaea=true},
 universe={achaea=true},
 }
 function mmp.rebuildOptionsTable(_,game)


### PR DESCRIPTION
I worked in support for universe tarot, as per request on the Achaea forums.
I was able to test the code with the Lusternia equivelant, Catacombs, before changing it over to Universe, so I'm fairly sure all is well with it.
I changed mmp.tempSpecialExit to have an optional weight parameter, so that you can easily weight a temporary exit if it takes longer than usual to use (like the 4-5 second delay for the tarot.)