### PR TITLE
Added Air Elemental "aero soar" support

### DIFF
--- a/mudlet-mapper.xml
+++ b/mudlet-mapper.xml
@@ -5687,14 +5687,14 @@ function mmp.addWingsAchaea()
   then
     --Sarapis soar.
     if mmp.oncontinent(getRoomArea(mmp.currentroom), &quot;Main&quot;) then
-			if gmcp.Char.Status.race == &quot;Elemental Lord&quot; then
+			if gmcp.Char.Status.class == &quot;air Elemental Lord&quot; or gmcp.Char.Status.class == &quot;air Elemental Lady&quot; then
       	mmp.tempSpecialExit(4882, &quot;aero soar high&quot;, 10) -- duanatharan
        	mmp.tempSpecialExit(3885, &quot;aero soar low&quot;, 10) -- duanathar
   			mmp.tempSpecialExit(54173, &quot;aero soar stratosphere&quot;, 10) -- Stratosphere!
 			end
 		--Meropis soar
     elseif mmp.oncontinent(getRoomArea(mmp.currentroom), &quot;Meropis&quot;) then
-			if gmcp.Char.Status.race == &quot;Elemental Lord&quot; then
+			if gmcp.Char.Status.class == &quot;air Elemental Lord&quot; or gmcp.Char.Status.class == &quot;air Elemental Lady&quot; then
       	mmp.tempSpecialExit(51603, &quot;aero soar high&quot;, 10) -- duanatharan
       	mmp.tempSpecialExit(51188, &quot;aero soar low&quot;, 10) -- duanathar
     		mmp.tempSpecialExit(54173, &quot;aero soar stratosphere&quot;, 10) -- Stratosphere!

--- a/mudlet-mapper.xml
+++ b/mudlet-mapper.xml
@@ -4817,7 +4817,7 @@ mmp.speedWalkPath = mmp.speedWalkPath or {}
 mmp.speedWalkDir = mmp.speedWalkDir or {}
 
 
-local newversion = &quot;developer&quot;
+local newversion = &quot;18.2.5&quot;
 if mmp.version and mmp.version ~= newversion then
   if not mmp.game then mmp.echo(&quot;Mapper script updated - Thanks! I don't know what game are you connected to, though - so please reconnect, if you could.&quot;)
   else mmp.echo(&quot;Mapper script updated - thanks! You don't need to restart.&quot;) end
@@ -4855,10 +4855,11 @@ function mmp.startup()
   private_settings[&quot;pebble&quot;]        = createOption(false, mmp.lockPebble, { &quot;boolean&quot; }, &quot;Make use of your enchanted pebble?&quot;)
   private_settings[&quot;removewings&quot;]   = createOption(true, mmp.setWingsRemoval, { &quot;boolean&quot; }, &quot;Remove Wings after using them?&quot;)
   private_settings[&quot;harness&quot;]				= createOption(false, mmp.setHarness, { &quot;boolean&quot; }, &quot;Use Stratospheric Harness?&quot;) --PapaGuacamole
-  private_settings[&quot;duantahar&quot;]     = createOption(false, mmp.setDuantahar, { &quot;boolean&quot; }, &quot;Use Chenubian Wings?&quot;)
+	private_settings[&quot;duantahar&quot;]     = createOption(false, mmp.setDuantahar, { &quot;boolean&quot; }, &quot;Use Chenubian Wings?&quot;)
   private_settings[&quot;duanatharan&quot;]   = createOption(false, mmp.setDuanatharan, { &quot;boolean&quot; }, &quot;Use Atavian Wings?&quot;)
   private_settings[&quot;duanathar&quot;]     = createOption(false, mmp.setDuanathar, { &quot;boolean&quot; }, &quot;Use Eagle Wings?&quot;)
-  private_settings[&quot;shackle&quot;]       = createOption(false, mmp.changeBoolFunc, { &quot;boolean&quot; }, &quot;Take off shackle?&quot;)
+  private_settings[&quot;soar&quot;]			   	= createOption(false, mmp.setSoar, { &quot;boolean&quot; }, &quot;Use Aero Soar?&quot;)
+	private_settings[&quot;shackle&quot;]       = createOption(false, mmp.changeBoolFunc, { &quot;boolean&quot; }, &quot;Take off shackle?&quot;)
   private_settings[&quot;universe&quot;]      = createOption(false, mmp.setUniverse, {&quot;boolean&quot; }, &quot;Use Universe Tarot?&quot;)
 
 --Lusternia bixes
@@ -5663,6 +5664,7 @@ function mmp.addWingsAchaea()
       end
     end
   end
+
   -- Stratospheric Harness support -- PapaGuacamole
   if
     mmp.settings.harness and gmcp.Room and not table.contains(gmcp.Room.Info.details, &quot;indoors&quot;)
@@ -5678,6 +5680,28 @@ function mmp.addWingsAchaea()
       mmp.tempSpecialExit(54632, &quot;Shake Harness&quot;)
     end
   end
+		
+	-- Air Elemental Aero Soar
+	  if
+			mmp.settings.soar and gmcp.Room and not table.contains(gmcp.Room.Info.details, &quot;indoors&quot;)
+  then
+    --Sarapis soar.
+    if mmp.oncontinent(getRoomArea(mmp.currentroom), &quot;Main&quot;) then
+			if not mmp.settings.duanatharan and not mmp.settings.duanathar and not mmp.settings.duantahar then
+        mmp.tempSpecialExit(4882, &quot;aero soar high&quot;) -- duanatharan
+        mmp.tempSpecialExit(3885, &quot;aero soar low&quot;) -- duanathar
+			end
+				mmp.tempSpecialExit(54173, &quot;aero soar stratosphere&quot;) -- Stratosphere!
+    --Meropis soar
+    elseif mmp.oncontinent(getRoomArea(mmp.currentroom), &quot;Meropis&quot;) then
+      if not mmp.settings.duanatharan and not mmp.settings.duanathar and not mmp.settings.duantahar then
+        mmp.tempSpecialExit(51603, &quot;aero soar high&quot;) -- duanatharan
+        mmp.tempSpecialExit(51188, &quot;aero soar low&quot;) -- duanathar
+			end
+    		mmp.tempSpecialExit(54173, &quot;aero soar stratosphere&quot;) -- Stratosphere!
+    end
+  end
+	
   --universe tarot
   if
     mmp.settings.universe and
@@ -6832,6 +6856,13 @@ function mmp.setDuantahar()
 
   if mmp.settings.duantahar then mmp.echo(&quot;Okay, will see about using Chenubian wings (duanathar, duanatharan, and duantahar) when you goto somewhere while outside!&quot;)
   else mmp.echo(&quot;Won't use Chenubian wings anymore.&quot;) end
+end
+
+function mmp.setSoar()
+  mmp.clearpathcache() -- clear the cache so it'll use soar or will stop using soar
+
+  if mmp.settings.soar then mmp.echo(&quot;Okay, will see about using Aero Soar when you goto somewhere while outside!&quot;)
+  else mmp.echo(&quot;Won't use Aero Soar anymore.&quot;) end
 end
 
 function mmp.setUniverse()
@@ -8225,9 +8256,9 @@ end</script>
                     <Script isActive="yes" isFolder="no">
                         <name>mmapper_achaea_went_outside</name>
                         <packageName></packageName>
-                        <script>-- track whenever we need to use wings when we get outside!
+                        <script>-- track whenever we need to use wings or aero soar when we get outside!
 function mmapper_achaea_went_outside()
-  if not mmp.autowalking or not (mmp.settings.duanathar or mmp.settings.duanatharan or mmp.settings.duantahar) or mmp.game ~= &quot;achaea&quot; or
+  if not mmp.autowalking or not (mmp.settings.duanathar or mmp.settings.duanatharan or mmp.settings.duantahar or mmp.settings.soar) or mmp.game ~= &quot;achaea&quot; or
     (mmp.currentroom == mmp.speedWalkPath[#mmp.speedWalkPath]) or
     table.contains(gmcp.Room.Info.details, &quot;indoors&quot;)
   then return end

--- a/mudlet-mapper.xml
+++ b/mudlet-mapper.xml
@@ -5690,6 +5690,8 @@ function mmp.addWingsAchaea()
 			if not mmp.settings.duanatharan and not mmp.settings.duanathar and not mmp.settings.duantahar then
         mmp.tempSpecialExit(4882, &quot;aero soar high&quot;) -- duanatharan
         mmp.tempSpecialExit(3885, &quot;aero soar low&quot;) -- duanathar
+			elseif mmp.settings.duanathar then
+				mmp.tempSpecialExit(4882, &quot;aero soar high&quot;) -- duanatharan
 			end
 				mmp.tempSpecialExit(54173, &quot;aero soar stratosphere&quot;) -- Stratosphere!
     --Meropis soar
@@ -5697,6 +5699,8 @@ function mmp.addWingsAchaea()
       if not mmp.settings.duanatharan and not mmp.settings.duanathar and not mmp.settings.duantahar then
         mmp.tempSpecialExit(51603, &quot;aero soar high&quot;) -- duanatharan
         mmp.tempSpecialExit(51188, &quot;aero soar low&quot;) -- duanathar
+			elseif mmp.settings.duanathar then
+				mmp.tempSpecialExit(51603, &quot;aero soar high&quot;) -- duanatharan
 			end
     		mmp.tempSpecialExit(54173, &quot;aero soar stratosphere&quot;) -- Stratosphere!
     end

--- a/mudlet-mapper.xml
+++ b/mudlet-mapper.xml
@@ -5687,14 +5687,18 @@ function mmp.addWingsAchaea()
   then
     --Sarapis soar.
     if mmp.oncontinent(getRoomArea(mmp.currentroom), &quot;Main&quot;) then
-    	mmp.tempSpecialExit(4882, &quot;aero soar high&quot;, 10) -- duanatharan
-     	mmp.tempSpecialExit(3885, &quot;aero soar low&quot;, 10) -- duanathar
-			mmp.tempSpecialExit(54173, &quot;aero soar stratosphere&quot;, 10) -- Stratosphere!
+			if gmcp.Char.Status.race == &quot;Elemental Lord&quot; then
+      	mmp.tempSpecialExit(4882, &quot;aero soar high&quot;, 10) -- duanatharan
+       	mmp.tempSpecialExit(3885, &quot;aero soar low&quot;, 10) -- duanathar
+  			mmp.tempSpecialExit(54173, &quot;aero soar stratosphere&quot;, 10) -- Stratosphere!
+			end
 		--Meropis soar
     elseif mmp.oncontinent(getRoomArea(mmp.currentroom), &quot;Meropis&quot;) then
-    	mmp.tempSpecialExit(51603, &quot;aero soar high&quot;, 10) -- duanatharan
-    	mmp.tempSpecialExit(51188, &quot;aero soar low&quot;, 10) -- duanathar
-    	mmp.tempSpecialExit(54173, &quot;aero soar stratosphere&quot;, 10) -- Stratosphere!
+			if gmcp.Char.Status.race == &quot;Elemental Lord&quot; then
+      	mmp.tempSpecialExit(51603, &quot;aero soar high&quot;, 10) -- duanatharan
+      	mmp.tempSpecialExit(51188, &quot;aero soar low&quot;, 10) -- duanathar
+    		mmp.tempSpecialExit(54173, &quot;aero soar stratosphere&quot;, 10) -- Stratosphere!
+			end
     end
   end
 	

--- a/mudlet-mapper.xml
+++ b/mudlet-mapper.xml
@@ -4817,7 +4817,7 @@ mmp.speedWalkPath = mmp.speedWalkPath or {}
 mmp.speedWalkDir = mmp.speedWalkDir or {}
 
 
-local newversion = &quot;18.2.5&quot;
+local newversion = &quot;developer&quot;
 if mmp.version and mmp.version ~= newversion then
   if not mmp.game then mmp.echo(&quot;Mapper script updated - Thanks! I don't know what game are you connected to, though - so please reconnect, if you could.&quot;)
   else mmp.echo(&quot;Mapper script updated - thanks! You don't need to restart.&quot;) end
@@ -5687,22 +5687,14 @@ function mmp.addWingsAchaea()
   then
     --Sarapis soar.
     if mmp.oncontinent(getRoomArea(mmp.currentroom), &quot;Main&quot;) then
-			if not mmp.settings.duanatharan and not mmp.settings.duanathar and not mmp.settings.duantahar then
-        mmp.tempSpecialExit(4882, &quot;aero soar high&quot;) -- duanatharan
-        mmp.tempSpecialExit(3885, &quot;aero soar low&quot;) -- duanathar
-			elseif mmp.settings.duanathar then
-				mmp.tempSpecialExit(4882, &quot;aero soar high&quot;) -- duanatharan
-			end
-				mmp.tempSpecialExit(54173, &quot;aero soar stratosphere&quot;) -- Stratosphere!
-    --Meropis soar
+    	mmp.tempSpecialExit(4882, &quot;aero soar high&quot;, 10) -- duanatharan
+     	mmp.tempSpecialExit(3885, &quot;aero soar low&quot;, 10) -- duanathar
+			mmp.tempSpecialExit(54173, &quot;aero soar stratosphere&quot;, 10) -- Stratosphere!
+		--Meropis soar
     elseif mmp.oncontinent(getRoomArea(mmp.currentroom), &quot;Meropis&quot;) then
-      if not mmp.settings.duanatharan and not mmp.settings.duanathar and not mmp.settings.duantahar then
-        mmp.tempSpecialExit(51603, &quot;aero soar high&quot;) -- duanatharan
-        mmp.tempSpecialExit(51188, &quot;aero soar low&quot;) -- duanathar
-			elseif mmp.settings.duanathar then
-				mmp.tempSpecialExit(51603, &quot;aero soar high&quot;) -- duanatharan
-			end
-    		mmp.tempSpecialExit(54173, &quot;aero soar stratosphere&quot;) -- Stratosphere!
+    	mmp.tempSpecialExit(51603, &quot;aero soar high&quot;, 10) -- duanatharan
+    	mmp.tempSpecialExit(51188, &quot;aero soar low&quot;, 10) -- duanathar
+    	mmp.tempSpecialExit(54173, &quot;aero soar stratosphere&quot;, 10) -- Stratosphere!
     end
   end
 	


### PR DESCRIPTION
Added aero soar support into the code.  It will allow using of aero soar ability by Air Elemental Lords in Achaea and will also soar to stratosphere to go to Tundra and Meropis.
Owners of Eagle's wings (duanathar) will still use duanathar since it is quicker (soar costs balance), but will be able to soar to duanatharan when needed.

mmapper_achaea_went_outside updated to support soar setting.