### PR TITLE
Rename the variable `goto`

### DIFF
--- a/mudlet-mapper.xml
+++ b/mudlet-mapper.xml
@@ -5073,9 +5073,9 @@ function mmp.gotoArea (where, number, dashtype, exact)
   local temp, maptable = yajl.to_value(tmp), {}
   for k,v in pairs(temp) do maptable[k:lower()] = v end
 
-  local goto = maptable[where]
-  if goto then
-  	mmp.gotoRoom(goto, dashtype)
+  local destinationRoom = maptable[where]
+  if destinationRoom then
+  	mmp.gotoRoom(destinationRoom, dashtype)
   	return
   end
 


### PR DESCRIPTION
This variable prevents us from using the formatter in a certain script. Additionally, should Mudlet move to Lua > 5.2 at some point, the name would become a reserved word and thus the script would stop working.