### PR TITLE
Changing to mmp.removeSpecialExit

### DIFF
--- a/mudlet-mapper.xml
+++ b/mudlet-mapper.xml
@@ -5573,20 +5573,22 @@ end</script>
                     <script>local exitsCreated = exitsCreated or {}
 
 function mmp.tempSpecialExit(destination, command, weight)
-  table.insert(exitsCreated, destination)
+  table.insert(exitsCreated, command)
   addSpecialExit(mmp.currentroom, destination, command)
-	if weight then
-	  setExitWeight(mmp.currentroom,command,weight)
-	end
+  if weight then
+    setExitWeight(mmp.currentroom, command, weight)
+  end
 end
 
 function mmp.removeWings()
-	--remove all special exits that were created by addWings, then resets the table.
-	mmp.clearspecials(exitsCreated)
-	exitsCreated={}
+  --remove all special exits that were created by addWings, then resets the table.
+  for _, command in ipairs(exitsCreated) do
+    removeSpecialExit(mmp.currentroom, command)
+  end
+  exitsCreated = {}
 end
 
-registerAnonymousEventHandler(&quot;mmp clear externals&quot;,&quot;mmp.removeWings&quot;)</script>
+registerAnonymousEventHandler(&quot;mmp clear externals&quot;, &quot;mmp.removeWings&quot;)</script>
                     <eventHandlerList/>
                 </Script>
                 <Script isActive="yes" isFolder="no">

--- a/mudlet-mapper.xml
+++ b/mudlet-mapper.xml
@@ -5541,11 +5541,11 @@ function mmp.fixSpecialExits(directions)
   end
 end
 
--- cleanup function to remove the temp special exit we made - only way to remove specials in Mudlet atm is by clearing them all
+-- cleanup function to remove the temp special exit we made
 function mmp.clearspecials(deleterooms)
   local t = getSpecialExits(mmp.currentroom)
   for connectingroom, exits in pairs(t) do
-    if table.contains(deleterooms,connectingroom) then -- delete this room
+    if table.contains(deleterooms,connectingroom) then -- delete the special exits linking to this room
       for command, locked in pairs(exits) do
         removeSpecialExit(mmp.currentroom, command)
       end

--- a/mudlet-mapper.xml
+++ b/mudlet-mapper.xml
@@ -5542,16 +5542,12 @@ function mmp.fixSpecialExits(directions)
 end
 
 -- cleanup function to remove the temp special exit we made - only way to remove specials in Mudlet atm is by clearing them all
-function mmp.clearspecials(ignorerooms)
+function mmp.clearspecials(deleterooms)
   local t = getSpecialExits(mmp.currentroom)
-  clearSpecialExits(mmp.currentroom)
-
   for connectingroom, exits in pairs(t) do
-    if not table.contains(ignorerooms,connectingroom) then -- don't re-add this one back as it's our temp
+    if table.contains(deleterooms,connectingroom) then -- delete this room
       for command, locked in pairs(exits) do
-        --debug echo: mmp.echo(&quot;need to re-link this room to &quot;..connectingroom..&quot; with &quot;..command..&quot; that is &quot;..(locked == &quot;1&quot; and &quot;locked&quot; or &quot;unlocked&quot;)..&quot;.&quot;)
-        addSpecialExit(mmp.currentroom, connectingroom, command)
-        if locked == &quot;1&quot; then lockSpecialExit(mmp.currentroom, connectingroom, command, true) end
+        removeSpecialExit(mmp.currentroom, command)
       end
     end
   end


### PR DESCRIPTION
some tweaks to mmp.clearSpecials and the wings cleanup function to use mmp.removeSpecialExit instead of clearing all the exits from the room then adding in ones that it didn't want to delete.

the wings stuff now tracks the temporary special exits it creates by the exit command, rather than destination room - This should keep it deleting any additional special exits linking the two rooms, if a permanent one exists. (Unlikely in practice, but possible.) 

Also, formatting! Woo!
Fixes #68