### PR TITLE
Fix the setting of the released version

### DIFF
--- a/travis.sh
+++ b/travis.sh
@@ -40,7 +40,7 @@ else
   versionPart=1
 fi
 version="$datePart.$versionPart"
-sed -rbe "s/local newversion = &quot;developer&quot;/local newversion = \&quot;$version\&quot;/g" "mudlet-mapper.xml" > "mudlet-mapper.xml.tmp" && mv "mudlet-mapper.xml.tmp" "mudlet-mapper.xml"
+sed -rbe "s/local newversion = \"developer\"/local newversion = \"$version\"/g" "mudlet-mapper.xml" > "mudlet-mapper.xml.tmp" && mv "mudlet-mapper.xml.tmp" "mudlet-mapper.xml"
 echo "$version" > version
 
 git config user.email "keneanung+ire-mapping@googlemail.com"


### PR DESCRIPTION
The recent change of the package file broke the release file so that a version "developer" was released. This fixes the bug. See https://github.com/IRE-Mudlet-Mapping/ire-mapping-script/commit/b7074332a484225d86247ad766ddfdd005f67ad7#commitcomment-30314667