### PR TITLE
Initial support for "goto feature <name> [gallop]"

### DIFF
--- a/mudlet-mapper.xml
+++ b/mudlet-mapper.xml
@@ -3649,83 +3649,118 @@ mmp.echo(string.format("Cleared all special exits in %s (%d).\n", getRoomName(ri
 				<Alias isActive="yes" isFolder="no">
 					<name>Create a room</name>
 					<script>local m = matches[2]
+if m:starts("feature") then
+  -- another alias was meant.
+  return
+end
 local rid, rname
 if mmp.roomexists(mmp.currentroom) then
   rid, rname = mmp.currentroom, mmp.currentroomname
 end
-local x,y,z
+local x, y, z
 
-local function set(newid) -- small func to set things
+local function set(newid)
+  -- small func to set things
   local rid = newid or createRoomID()
   addRoom(rid)
   setRoomCoordinates(rid, x, y, z)
-  if mmp.roomexists(mmp.currentroom) then setRoomArea(rid, getRoomArea(mmp.currentroom)) end
-  if mmp.roomexists(mmp.currentroom) then setRoomEnv(rid, getRoomEnv(mmp.currentroom)) end
+  if mmp.roomexists(mmp.currentroom) then
+    setRoomArea(rid, getRoomArea(mmp.currentroom))
+  end
+  if mmp.roomexists(mmp.currentroom) then
+    setRoomEnv(rid, getRoomEnv(mmp.currentroom))
+  end
   setExit(mmp.currentroom, rid, m)
-  mmp.echo(string.format("Created new room (%d) at %dx, %dy, %dz.\n", rid, x,y,z))
+  mmp.echo(string.format("Created new room (%d) at %dx, %dy, %dz.\n", rid, x, y, z))
   centerview(mmp.roomexists(mmp.currentroom) and mmp.currentroom or rid)
-  if not mmp.roomexists(mmp.currentroom) then mmp.currentroom = rid; mmp.currentroomname = "" end
+  if not mmp.roomexists(mmp.currentroom) then
+    mmp.currentroom = rid;
+    mmp.currentroomname = ""
+  end
 end
 
 -- let's be flexible and allow several ways if giving an arg
 -- rc v# x y z
-newid, x,y,z = string.match(m, "v(%d+) (%-?%d+) (%-?%d+) (%-?%d+)")
+newid, x, y, z = string.match(m, "v(%d+) (%-?%d+) (%-?%d+) (%-?%d+)")
 if x then
-  set(newid); return
+  set(newid);
+  return
 end
-
 -- rc x y z
-x,y,z = string.match(m, "(%-?%d+) (%-?%d+) (%-?%d+)")
+x, y, z = string.match(m, "(%-?%d+) (%-?%d+) (%-?%d+)")
 if x then
-  set(); return
+  set();
+  return
 end
-
-
 if not rid then
   mmp.echo("Don't know where we are at the moment in order to use relative coordinates.")
   return
 end
-
 -- rc xx? yy? zz?
-x,y,z = string.match(m, "(%-?%d+)x"), string.match(m, "(%-?%d+)y"), string.match(m, "(%-?%d+)z")
+x, y, z = string.match(m, "(%-?%d+)x"), string.match(m, "(%-?%d+)y"), string.match(m, "(%-?%d+)z")
 if x or y or z then
   -- merge w/ old coords if any are missing
   local ox, oy, oz = getRoomCoordinates(rid)
-  x = x or ox; y = y or oy; z = z or oz
-  set(); return
+  x = x or ox;
+  y = y or oy;
+  z = z or oz
+  set();
+  return
 end
-
 -- rc left/west, right/east, ...
 local ox, oy, oz = getRoomCoordinates(rid)
 local has = table.contains
 for w in string.gmatch(m, "%a+") do
   if has({"west", "left", "w", "l"}, w) then
-    x = (x or ox) - 1; y = (y or oy); z = (z or oz)
+    x = (x or ox) - 1;
+    y = (y or oy);
+    z = (z or oz)
   elseif has({"east", "right", "e", "r"}, w) then
-    x = (x or ox) + 1; y = (y or oy); z = (z or oz)
+    x = (x or ox) + 1;
+    y = (y or oy);
+    z = (z or oz)
   elseif has({"north", "top", "n", "t"}, w) then
-    x = (x or ox); y = (y or oy) + 1; z = (z or oz)
+    x = (x or ox);
+    y = (y or oy) + 1;
+    z = (z or oz)
   elseif has({"south", "bottom", "s", "b"}, w) then
-    x = (x or ox); y = (y or oy) - 1; z = (z or oz)
+    x = (x or ox);
+    y = (y or oy) - 1;
+    z = (z or oz)
   elseif has({"northwest", "topleft", "nw", "tl"}, w) then
-    x = (x or ox) - 1; y = (y or oy) + 1; z = (z or oz)
+    x = (x or ox) - 1;
+    y = (y or oy) + 1;
+    z = (z or oz)
   elseif has({"northeast", "topright", "ne", "tr"}, w) then
-    x = (x or ox) + 1; y = (y or oy) + 1; z = (z or oz)
+    x = (x or ox) + 1;
+    y = (y or oy) + 1;
+    z = (z or oz)
   elseif has({"southeast", "bottomright", "se", "br"}, w) then
-    x = (x or ox) + 1; y = (y or oy) - 1; z = (z or oz)
+    x = (x or ox) + 1;
+    y = (y or oy) - 1;
+    z = (z or oz)
   elseif has({"southwest", "bottomleft", "sw", "bl"}, w) then
-    x = (x or ox) - 1; y = (y or oy) - 1; z = (z or oz)
+    x = (x or ox) - 1;
+    y = (y or oy) - 1;
+    z = (z or oz)
   elseif has({"up", "u"}, w) then
-    x = (x or ox); y = (y or oy); z = (z or oz) + 1
+    x = (x or ox);
+    y = (y or oy);
+    z = (z or oz) + 1
   elseif has({"down", "d"}, w) then
-    x = (x or ox); y = (y or oy); z = (z or oz) - 1
+    x = (x or ox);
+    y = (y or oy);
+    z = (z or oz) - 1
   end
-
 end
-if x then set(); return end
-
-mmp.echo([[Where do you want to move the room to?
-  You can use direct coordinates or relative directions.]])</script>
+if x then
+  set();
+  return
+end
+mmp.echo(
+  [[Where do you want to move the room to?
+  You can use direct coordinates or relative directions.]]
+)</script>
 					<command></command>
 					<packageName></packageName>
 					<regex>^(?:rlc|room create) (.+)?$</regex>
@@ -4198,6 +4233,13 @@ end</script>
 					<command></command>
 					<packageName></packageName>
 					<regex>^feature list$</regex>
+				</Alias>
+				<Alias isActive="yes" isFolder="no">
+					<name>Add map feature to room</name>
+					<script>mmp.roomCreateMapFeature(matches[3], matches[2] == "" and mmp.currentroom or tonumber(matches[2]))</script>
+					<command></command>
+					<packageName></packageName>
+					<regex>^(?:room create feature|rcf) (?:v(\d+) )?(.+)$</regex>
 				</Alias>
 				<Alias isActive="no" isFolder="no">
 					<name>-- (dangerous functions)</name>
@@ -10964,6 +11006,54 @@ function mmp.listMapFeatures()
   echo(string.format("    %s\n", string.rep("-", 45)))
   for featureName, roomCharacter in pairs(mapFeatures) do
     echo(string.format("    %-25s | %s\n", featureName, roomCharacter))
+  end
+end
+
+function mmp.roomCreateMapFeature(featureName, roomId)
+  -- checks for the feature name
+  if not featureName then
+    mmp.echo("Which feature would you like to create?")
+    return
+  end
+  local lowerFeatureName = featureName:lower()
+  local mapFeatures = loadMapFeatures()
+  if not mapFeatures[lowerFeatureName] then
+    mmp.echo(
+      "A feature with name '" ..
+      featureName ..
+      "' does not exist. You need to use 'feature create' first."
+    )
+    return
+  end
+  -- checks for the room ID
+  if not roomId then
+    if not mmp.currentroom then
+      mmp.echo("Don't know where we are at the moment.")
+      return
+    end
+    roomId = mmp.currentroom
+  else
+    if type(roomId) ~= "number" then
+      mmp.echo("Need a room ID as number for creating a map feature on a room.")
+      return
+    end
+  end
+  if not getRoomName(roomId) then
+    mmp.echo("Room number '" .. roomId .. "' does not exist.")
+    return
+  end
+	-- check if feature already exists
+	if getRoomUserData(roomId, "feature-" .. lowerFeatureName) == "true" then
+	  mmp.echo("Room '" .. roomId .. "' has already map feature '" .. lowerFeatureName .. "'.")
+		return
+	end
+  -- create map feature in room
+  setRoomUserData(roomId, "feature-" .. lowerFeatureName, "true")
+  mmp.echo(string.format("Map feature '%s' created in room number '%d'.", featureName, roomId))
+  local featureRoomChar = mapFeatures[lowerFeatureName]
+  if featureRoomChar ~= "" then
+    setRoomChar(roomId, featureRoomChar)
+    mmp.echo("The room now carries the room char '" .. featureRoomChar .. "'.")
   end
 end</script>
 				<eventHandlerList />

--- a/mudlet-mapper.xml
+++ b/mudlet-mapper.xml
@@ -8540,6 +8540,16 @@ end</script>
         end
       end
     end
+    local mapFeatureString = getMapUserData("mapFeatures")
+    if mapFeatureString then
+      local mapFeatures = yajl.to_value(mapFeatureString)
+      local message = "This room has the feature '%s'."
+      for mapFeature in pairs(mapFeatures) do
+        if getRoomUserData(num, "feature-" .. mapFeature) == "true" then
+          mmp.echo(string.format(message, mapFeature))
+        end
+      end
+    end
     -- actions we can do. This will be a short menu of sorts for actions
     mmp.echo("Stuff you can do:")
     echo("  ")

--- a/mudlet-mapper.xml
+++ b/mudlet-mapper.xml
@@ -4346,6 +4346,13 @@ end</script>
 					<packageName></packageName>
 					<regex>^spe delete all(?: (.+))?$</regex>
 				</Alias>
+				<Alias isActive="yes" isFolder="no">
+					<name>Add map feature</name>
+					<script>mmp.createMapFeature(matches[2]:trim(), matches[3]:trim())</script>
+					<command></command>
+					<packageName></packageName>
+					<regex>^feature create (.+?)(?: char (.+))?$</regex>
+				</Alias>
 			</AliasGroup>
 			<Alias isActive="yes" isFolder="no">
 				<name>Toggle mapping mode</name>
@@ -10876,6 +10883,62 @@ end
 						<string>mapOpenEvent</string>
 					</eventHandlerList>
 				</Script>
+			</Script>
+			<Script isActive="yes" isFolder="no">
+				<name>map features</name>
+				<packageName></packageName>
+				<script>-------------------------------------------------
+--         Put your Lua functions here.        --
+--                                             --
+-- Note that you can also use external Scripts --
+-------------------------------------------------
+
+local function loadMapFeatures()
+  local mapFeaturesString = getRoomUserData(1, "mapFeatures")
+  local mapFeatures
+  if mapFeaturesString and mapFeaturesString ~= "" then
+    mapFeatures = yajl.to_value(mapFeaturesString)
+  else
+    mapFeatures = {}
+  end
+  return mapFeatures
+end
+
+local function saveMapFeatures(mapFeaturesToSave)
+  local mapFeaturesString = yajl.to_string(mapFeaturesToSave)
+  setRoomUserData(1, "mapFeatures", mapFeaturesString)
+end
+
+function mmp.createMapFeature(featureName, roomCharacter)
+  if not featureName or featureName == "" then
+    mmp.echo("Can't create an empty map feature.")
+    return
+  end
+  roomCharacter = roomCharacter or ""
+  if type(roomCharacter) ~= "string" then
+    mmp.echo(
+      "The new room character must be either a string or nil. " ..
+      type(roomCharacter) ..
+      " is not allowed."
+    )
+    return
+  end
+  local mapFeatures = loadMapFeatures()
+  if not mapFeatures[featureName] then
+    mapFeatures[featureName] = roomCharacter
+    saveMapFeatures(mapFeatures)
+    mmp.echo(
+      "Created map feature '" ..
+      featureName ..
+      "' with the room character '" ..
+      roomCharacter ..
+      "'."
+    )
+  else
+    mmp.echo("A map feature with the name '" .. featureName .. "' already exists.")
+  end
+end</script>
+				<eventHandlerList />
 			</Script>
 		</ScriptGroup>
 	</ScriptPackage>

--- a/mudlet-mapper.xml
+++ b/mudlet-mapper.xml
@@ -4221,7 +4221,7 @@ end</script>
 					<regex></regex>
 				</Alias>
 				<Alias isActive="yes" isFolder="no">
-					<name>Add map feature</name>
+					<name>Create map feature</name>
 					<script>mmp.createMapFeature(matches[2]:trim(), (matches[3] and matches[3]:trim()))</script>
 					<command></command>
 					<packageName></packageName>
@@ -4242,11 +4242,18 @@ end</script>
 					<regex>^(?:room create feature|rcf) (?:v(\d+) )?(.+)$</regex>
 				</Alias>
 				<Alias isActive="yes" isFolder="no">
-					<name>delete map feature from room</name>
+					<name>Delete map feature from room</name>
 					<script>mmp.roomDeleteMapFeature(matches[3], matches[2] == "" and mmp.currentroom or tonumber(matches[2]))</script>
 					<command></command>
 					<packageName></packageName>
 					<regex>^(?:room delete feature|rdf) (?:v(\d+) )?(.+)$</regex>
+				</Alias>
+				<Alias isActive="yes" isFolder="no">
+					<name>Delete map feature</name>
+					<script>mmp.deleteMapFeature(matches[2]:trim())</script>
+					<command></command>
+					<packageName></packageName>
+					<regex>^feature delete (.+)$</regex>
 				</Alias>
 				<Alias isActive="no" isFolder="no">
 					<name>-- (dangerous functions)</name>
@@ -10994,9 +11001,10 @@ function mmp.createMapFeature(featureName, roomCharacter)
     )
     return
   end
+  local lowerFeatureName = featureName:lower()
   local mapFeatures = loadMapFeatures()
-  if not mapFeatures[featureName] then
-    mapFeatures[featureName] = roomCharacter
+  if not mapFeatures[lowerFeatureName] then
+    mapFeatures[lowerFeatureName] = roomCharacter
     saveMapFeatures(mapFeatures)
     mmp.echo(
       "Created map feature '" ..
@@ -11007,7 +11015,9 @@ function mmp.createMapFeature(featureName, roomCharacter)
     )
   else
     mmp.echo("A map feature with the name '" .. featureName .. "' already exists.")
+    return
   end
+  return true
 end
 
 function mmp.listMapFeatures()
@@ -11018,6 +11028,7 @@ function mmp.listMapFeatures()
   for featureName, roomCharacter in pairs(mapFeatures) do
     echo(string.format("    %-25s | %s\n", featureName, roomCharacter))
   end
+  return true
 end
 
 function mmp.roomCreateMapFeature(featureName, roomId)
@@ -11066,6 +11077,7 @@ function mmp.roomCreateMapFeature(featureName, roomId)
     setRoomChar(roomId, featureRoomChar)
     mmp.echo("The room now carries the room char '" .. featureRoomChar .. "'.")
   end
+  return true
 end
 
 function mmp.roomDeleteMapFeature(featureName, roomId)
@@ -11106,7 +11118,7 @@ function mmp.roomDeleteMapFeature(featureName, roomId)
   roomMapFeatures = mmp.getRoomMapFeatures(roomId)
   local mapFeatures = loadMapFeatures()
   -- find out if we need to set a new room character
-  if getRoomChar(roomId) == mapFeatures[lowerFeatureName] then
+  if getRoomChar(roomId) == mapFeatures[lowerFeatureName] and getRoomChar(roomId) ~= "" then
     local index, otherRoomMapFeature
     -- find another usable room character
     repeat
@@ -11123,6 +11135,7 @@ function mmp.roomDeleteMapFeature(featureName, roomId)
       mmp.echo("Deleted the current room character.")
     end
   end
+  return true
 end
 
 function mmp.getRoomMapFeatures(roomId)
@@ -11151,6 +11164,35 @@ function mmp.getRoomMapFeatures(roomId)
     end
   end
   return result
+end
+
+function mmp.deleteMapFeature(featureName)
+  if not featureName or featureName == "" then
+    mmp.echo("Which map feature would you like to delete?")
+    return
+  end
+  local lowerFeatureName = featureName:lower()
+  local mapFeatures = loadMapFeatures()
+  if not mapFeatures[lowerFeatureName] then
+    mmp.echo("Map feature '" .. featureName .. "' does not exist.")
+    return
+  end
+  local roomsWithFeature = searchRoomUserData("feature-" .. lowerFeatureName, "true")
+  for _, roomId in pairs(roomsWithFeature) do
+    local deletionResult = mmp.roomDeleteMapFeature(lowerFeatureName, roomId)
+    if not deletionResult then
+      mmp.echo(
+        "Something went wrong deleting the map feature '" ..
+        featureName ..
+        "' from all rooms. Deletion incomplete."
+      )
+      return
+    end
+  end
+  mapFeatures[lowerFeatureName] = nil
+  saveMapFeatures(mapFeatures)
+  mmp.echo("Deleted map feature '" .. featureName .. "' from map.")
+  return true
 end</script>
 				<eventHandlerList />
 			</Script>

--- a/mudlet-mapper.xml
+++ b/mudlet-mapper.xml
@@ -4354,7 +4354,7 @@ end</script>
 					<regex>^feature create (.+?)(?: char (.+))?$</regex>
 				</Alias>
 				<Alias isActive="yes" isFolder="no">
-					<name>list map features</name>
+					<name>List map features</name>
 					<script>mmp.listMapFeatures()</script>
 					<command></command>
 					<packageName></packageName>
@@ -10901,7 +10901,7 @@ end
 -------------------------------------------------
 
 local function loadMapFeatures()
-  local mapFeaturesString = getRoomUserData(1, "mapFeatures")
+  local mapFeaturesString = getMapUserData("mapFeatures")
   local mapFeatures
   if mapFeaturesString and mapFeaturesString ~= "" then
     mapFeatures = yajl.to_value(mapFeaturesString)
@@ -10913,12 +10913,16 @@ end
 
 local function saveMapFeatures(mapFeaturesToSave)
   local mapFeaturesString = yajl.to_string(mapFeaturesToSave)
-  setRoomUserData(1, "mapFeatures", mapFeaturesString)
+  setMapUserData("mapFeatures", mapFeaturesString)
 end
 
 function mmp.createMapFeature(featureName, roomCharacter)
   if not featureName or featureName == "" then
     mmp.echo("Can't create an empty map feature.")
+    return
+  end
+  if featureName:find("%d") then
+    mmp.echo("Map feature names must not contain numbers.")
     return
   end
   roomCharacter = roomCharacter or ""

--- a/mudlet-mapper.xml
+++ b/mudlet-mapper.xml
@@ -4255,6 +4255,48 @@ end</script>
 					<packageName></packageName>
 					<regex>^feature delete (.+)$</regex>
 				</Alias>
+				<Alias isActive="yes" isFolder="no">
+					<name>migrate features</name>
+					<script>local translation
+if mmp.game == "starmourn" then
+  translation =
+  {
+    ["@"] = "landing dock",
+    ["C"] = "cloning",
+    ["R"] = "repair",
+    ["$"] = "denizen shop",
+    ["I"] = "insurance office",
+    ["T"] = "transport",
+    ["J"] = "junk",
+    ["M"] = "mall",
+    ["L"] = "lift",
+    ["P"] = "ptp",
+    ["TT"] = "trade terminal",
+  }
+else
+  mmp.echo("Sorry, don't know which room character maps to which map feature for your game. Please contact us at https://discord.gg/PPUNnc3 to get this sorted out.")
+	return
+end
+mmp.echo("Migrating room characters to map features...")
+for char, feature in pairs(translation) do
+  mmp.createMapFeature(feature, char)
+end
+for key in pairs(getRooms()) do
+  local char = getRoomChar(key)
+  if char ~= "" then
+    if translation[char] then
+      if not mmp.roomCreateMapFeature(translation[char], key) then
+			  mmp.echo("An error occured when migrating room characters, see messages above for details. Migration incomplete!")
+			  return
+			end
+    end
+  end
+end
+mmp.echo("Migration done.")</script>
+					<command></command>
+					<packageName></packageName>
+					<regex>^feature migrate$</regex>
+				</Alias>
 				<Alias isActive="no" isFolder="no">
 					<name>-- (dangerous functions)</name>
 					<script></script>

--- a/mudlet-mapper.xml
+++ b/mudlet-mapper.xml
@@ -4353,6 +4353,13 @@ end</script>
 					<packageName></packageName>
 					<regex>^feature create (.+?)(?: char (.+))?$</regex>
 				</Alias>
+				<Alias isActive="yes" isFolder="no">
+					<name>list map features</name>
+					<script>mmp.listMapFeatures()</script>
+					<command></command>
+					<packageName></packageName>
+					<regex>^feature list$</regex>
+				</Alias>
 			</AliasGroup>
 			<Alias isActive="yes" isFolder="no">
 				<name>Toggle mapping mode</name>
@@ -10936,6 +10943,16 @@ function mmp.createMapFeature(featureName, roomCharacter)
     )
   else
     mmp.echo("A map feature with the name '" .. featureName .. "' already exists.")
+  end
+end
+
+function mmp.listMapFeatures()
+  local mapFeatures = loadMapFeatures()
+  mmp.echo("This map has the following features:")
+  echo(string.format("    %-25s | %s\n", "feature name", "room character"))
+  echo(string.format("    %s\n", string.rep("-", 45)))
+  for featureName, roomCharacter in pairs(mapFeatures) do
+    echo(string.format("    %-25s | %s\n", featureName, roomCharacter))
   end
 end</script>
 				<eventHandlerList />

--- a/mudlet-mapper.xml
+++ b/mudlet-mapper.xml
@@ -2855,24 +2855,24 @@ mmp.game = "starmourn"</script>
 					</regexCodePropertyList>
 				</Trigger>
 				<Trigger isActive="yes" isFolder="no" isTempTrigger="no" isMultiline="no" isPerlSlashGOption="no" isColorizerTrigger="no" isFilterTrigger="no" isSoundTrigger="no" isColorTrigger="no" isColorTriggerFg="no" isColorTriggerBg="no">
-						<name>Path Blocked</name>
-						<script>mmp.failpath()</script>
-						<triggerType>0</triggerType>
-						<conditonLineDelta>0</conditonLineDelta>
-						<mStayOpen>0</mStayOpen>
-						<mCommand></mCommand>
-						<packageName></packageName>
-						<mFgColor>#ff0000</mFgColor>
-						<mBgColor>#ffff00</mBgColor>
-						<mSoundFile></mSoundFile>
-						<colorTriggerFgColor>#000000</colorTriggerFgColor>
-						<colorTriggerBgColor>#000000</colorTriggerBgColor>
-						<regexCodeList>
-							<string>^.+ blocks your attempt to leave. You can attempt to CRASH \w+ to escape\.$</string>
-						</regexCodeList>
-						<regexCodePropertyList>
-							<integer>1</integer>
-						</regexCodePropertyList>
+					<name>Path Blocked</name>
+					<script>mmp.failpath()</script>
+					<triggerType>0</triggerType>
+					<conditonLineDelta>0</conditonLineDelta>
+					<mStayOpen>0</mStayOpen>
+					<mCommand></mCommand>
+					<packageName></packageName>
+					<mFgColor>#ff0000</mFgColor>
+					<mBgColor>#ffff00</mBgColor>
+					<mSoundFile></mSoundFile>
+					<colorTriggerFgColor>#000000</colorTriggerFgColor>
+					<colorTriggerBgColor>#000000</colorTriggerBgColor>
+					<regexCodeList>
+						<string>^.+ blocks your attempt to leave. You can attempt to CRASH \w+ to escape\.$</string>
+					</regexCodeList>
+					<regexCodePropertyList>
+						<integer>1</integer>
+					</regexCodePropertyList>
 				</Trigger>
 			</TriggerGroup>
 			<TriggerGroup isActive="yes" isFolder="yes" isTempTrigger="no" isMultiline="no" isPerlSlashGOption="no" isColorizerTrigger="no" isFilterTrigger="no" isSoundTrigger="no" isColorTrigger="no" isColorTriggerFg="no" isColorTriggerBg="no">
@@ -3381,27 +3381,29 @@ elseif command:ends("glide") then
   gallop = "glide"
   where = where:sub(1, -7)
 end
-
 if mmp.debug then
   mmp.gotoPerf = mmp.gotoPerf or createStopWatch()
   startStopWatch(mmp.gotoPerf)
 end
-
 -- goto room ID
 if tonumber(where) then
-	mmp.gotoRoom(where, gallop)
+  mmp.gotoRoom(where, gallop)
 else
-	-- goto area
-    local split = where:split(" ")
+  -- goto area or feature
+  local split = where:split(" ")
+  if split[1] == "feature" then
+	  table.remove(split, 1)
+    mmp.gotoFeature(table.concat(split, " "), gallop)
+  else
     if tonumber(split[#split]) then
-        mmp.gotoArea(where:sub(1, -#(split[#split])-2), tonumber(split[#split]), gallop)
+      mmp.gotoArea(where:sub(1, -#(split[#split]) - 2), tonumber(split[#split]), gallop)
     else
-        mmp.gotoArea(where, nil, gallop)
+      mmp.gotoArea(where, nil, gallop)
     end
+  end
 end
-
 if mmp.debug then
-  mmp.echo("goto alias took "..stopStopWatch(mmp.gotoPerf).."s to run.")
+  mmp.echo("goto alias took " .. stopStopWatch(mmp.gotoPerf) .. "s to run.")
 end</script>
 				<command></command>
 				<packageName></packageName>
@@ -5722,7 +5724,7 @@ function speedwalking(event, num)
       (
         table.contains(gmcp.Room.Info.details, "indoors") or
         table.contains(gmcp.Room.Info.details, "considered indoors") or
-				mmp.orbed()
+        mmp.orbed()
       )
     then
       mmp.inside = true
@@ -5843,7 +5845,7 @@ function doSpeedWalk(dashtype)
       "&lt;" .. mmp.settings.echocolour .. "&gt;" .. mmp.speedWalkPath[#mmp.speedWalkPath],
       'mmp.gotoRoom "' .. mmp.speedWalkPath[#mmp.speedWalkPath] .. '"',
       'Go to ' .. mmp.speedWalkPath[#mmp.speedWalkPath],
-			true
+      true
     )
     echo(": ")
     speedWalkCounter = 1
@@ -5972,33 +5974,20 @@ function mmp.clearspecials(deleterooms)
   end
 end
 
-function mmp.gotoAreaID(areaid, number, dashtype)
-  if not areaid or not tonumber(areaid) then
-    mmp.echo("To where do you want to go?")
-    return
-  end
-  areaid = tonumber(areaid)
-  if not mmp.areatabler[areaid] then
-    mmp.echo("Invalid area ID selected")
-    return
-  end
-  local possibleRooms, shortestPath, shortestBorder = {}, {}, 0
+local function getShortestOfMultipleRooms(possibleRooms)
+  local shortestPath, closestRoom = {}, 0
   mmp.computeShortestWatch = mmp.computeShortestWatch or createStopWatch()
   startStopWatch(mmp.computeShortestWatch)
-  possibleRooms = mmp.getAreaBorders(areaid)
-  -- add in temporary links to clouds / stratospheres to enable pathfinding, auto-repath will occur when moved to outside -- PapaGuacamole
-  local madeEast, madeNorth, madeWest
-  local currentareaid = getRoomArea(mmp.currentroom)
   raiseEvent("mmp link externals")
   local getStopWatchTime, tonumber, getPath = getStopWatchTime, tonumber, mmp.getPath
-  --mmp.echo(string.format("Have %s area edge nodes, %ss taken so far...", table.size(possibleRooms), getStopWatchTime(mmp.computeShortestWatch)))
+  --mmp.echo(string.format("Have %s rooms nodes, %ss taken so far...", table.size(possibleRooms), getStopWatchTime(mmp.computeShortestWatch)))
   -- allocate only 500ms to finding the shortest path, or more if we failed to find anything
   local checkedsofar, outoftime = 0
   for id, _ in pairs(possibleRooms) do
     if mmp.getPath(mmp.currentroom, tonumber(id)) then
-      if shortestBorder == 0 or #shortestPath &gt; #speedWalkPath then
+      if closestRoom == 0 or #shortestPath &gt; #speedWalkPath then
         shortestPath = speedWalkPath
-        shortestBorder = tonumber(id)
+        closestRoom = tonumber(id)
       end
     end
     checkedsofar = checkedsofar + 1
@@ -6010,6 +5999,22 @@ function mmp.gotoAreaID(areaid, number, dashtype)
   end
   --mmp.echo(string.format("total time took: %s", getStopWatchTime(mmp.computeShortestWatch)))
   stopStopWatch(mmp.computeShortestWatch)
+  return closestRoom, outoftime, checkedsofar
+end
+
+function mmp.gotoAreaID(areaid, number, dashtype)
+  if not areaid or not tonumber(areaid) then
+    mmp.echo("To where do you want to go?")
+    return
+  end
+  areaid = tonumber(areaid)
+  if not mmp.areatabler[areaid] then
+    mmp.echo("Invalid area ID selected")
+    return
+  end
+  local possibleRooms, shortestBorder = {}, 0
+  possibleRooms = mmp.getAreaBorders(areaid)
+  shortestBorder, outoftime, checkedsofar = getShortestOfMultipleRooms(possibleRooms)
   if shortestBorder == 0 then
     if outoftime then
       mmp.echo(
@@ -6017,7 +6022,7 @@ function mmp.gotoAreaID(areaid, number, dashtype)
           "I checked %d of the %d possible exits \"%s\" has, but none of the ways there worked and it was taking too long :( try doing this again?",
           checkedsofar,
           table.size(possibleRooms),
-          where
+          getRoomAreaName(areaid)
         )
       )
     else
@@ -6036,6 +6041,54 @@ function mmp.gotoAreaID(areaid, number, dashtype)
   end
   raiseEvent("mmp clear externals")
   mmp.gotoRoom(shortestBorder, dashtype, "area")
+end
+
+function mmp.gotoFeature(partialFeatureName, dashtype)
+  local userDataKeys = searchRoomUserData()
+  local feature
+  for _, key in pairs(userDataKeys) do
+    if key:starts("feature-") and key:find(partialFeatureName:lower()) then
+      feature = key
+      break
+    end
+  end
+  if not feature then
+    mmp.echo("No feature like " .. partialFeatureName .. " found.")
+    return
+  end
+  local rooms = searchRoomUserData(feature, "true")
+  -- change the structure of the table so it fits getShortestOfMultipleRooms
+  local possibleRooms = {}
+  for _, room in pairs(rooms) do
+    possibleRooms[room] = true
+  end
+  closestFeature, outoftime, checkedsofar = getShortestOfMultipleRooms(possibleRooms)
+  if closestFeature == 0 then
+    if outoftime then
+      mmp.echo(
+        string.format(
+          "I checked %d of the %d possible features \"%s\" has, but none of the ways there worked and it was taking too long :( try doing this again?",
+          checkedsofar,
+          table.size(possibleRooms),
+          partialFeatureName
+        )
+      )
+    else
+      mmp.echo(
+        "Checked " ..
+        table.size(possibleRooms) ..
+        " rooms with that feature, and none of them worked :( I Don't know how to get you there."
+      )
+    end
+    mmp.speedWalkPath = {}
+    mmp.speedWalkDir = {}
+    speedWalkCounter = 0
+    raiseEvent("mmapper failed path")
+    raiseEvent("mmp clear externals")
+    return
+  end
+  raiseEvent("mmp clear externals")
+  mmp.gotoRoom(closestFeature, dashtype, "area")
 end</script>
 				<eventHandlerList>
 					<string>RoomNum</string>

--- a/mudlet-mapper.xml
+++ b/mudlet-mapper.xml
@@ -4179,6 +4179,27 @@ end</script>
 					<regex>^weight ferry exits$</regex>
 				</Alias>
 				<Alias isActive="no" isFolder="no">
+					<name>-- (Map feature functions)</name>
+					<script></script>
+					<command></command>
+					<packageName></packageName>
+					<regex></regex>
+				</Alias>
+				<Alias isActive="yes" isFolder="no">
+					<name>Add map feature</name>
+					<script>mmp.createMapFeature(matches[2]:trim(), matches[3]:trim())</script>
+					<command></command>
+					<packageName></packageName>
+					<regex>^feature create (.+?)(?: char (.+))?$</regex>
+				</Alias>
+				<Alias isActive="yes" isFolder="no">
+					<name>List map features</name>
+					<script>mmp.listMapFeatures()</script>
+					<command></command>
+					<packageName></packageName>
+					<regex>^feature list$</regex>
+				</Alias>
+				<Alias isActive="no" isFolder="no">
 					<name>-- (dangerous functions)</name>
 					<script></script>
 					<command></command>
@@ -4345,20 +4366,6 @@ end</script>
 					<command></command>
 					<packageName></packageName>
 					<regex>^spe delete all(?: (.+))?$</regex>
-				</Alias>
-				<Alias isActive="yes" isFolder="no">
-					<name>Add map feature</name>
-					<script>mmp.createMapFeature(matches[2]:trim(), matches[3]:trim())</script>
-					<command></command>
-					<packageName></packageName>
-					<regex>^feature create (.+?)(?: char (.+))?$</regex>
-				</Alias>
-				<Alias isActive="yes" isFolder="no">
-					<name>List map features</name>
-					<script>mmp.listMapFeatures()</script>
-					<command></command>
-					<packageName></packageName>
-					<regex>^feature list$</regex>
 				</Alias>
 			</AliasGroup>
 			<Alias isActive="yes" isFolder="no">

--- a/mudlet-mapper.xml
+++ b/mudlet-mapper.xml
@@ -4222,7 +4222,7 @@ end</script>
 				</Alias>
 				<Alias isActive="yes" isFolder="no">
 					<name>Add map feature</name>
-					<script>mmp.createMapFeature(matches[2]:trim(), matches[3]:trim())</script>
+					<script>mmp.createMapFeature(matches[2]:trim(), (matches[3] and matches[3]:trim()))</script>
 					<command></command>
 					<packageName></packageName>
 					<regex>^feature create (.+?)(?: char (.+))?$</regex>
@@ -4240,6 +4240,13 @@ end</script>
 					<command></command>
 					<packageName></packageName>
 					<regex>^(?:room create feature|rcf) (?:v(\d+) )?(.+)$</regex>
+				</Alias>
+				<Alias isActive="yes" isFolder="no">
+					<name>delete map feature from room</name>
+					<script>mmp.roomDeleteMapFeature(matches[3], matches[2] == "" and mmp.currentroom or tonumber(matches[2]))</script>
+					<command></command>
+					<packageName></packageName>
+					<regex>^(?:room delete feature|rdf) (?:v(\d+) )?(.+)$</regex>
 				</Alias>
 				<Alias isActive="no" isFolder="no">
 					<name>-- (dangerous functions)</name>
@@ -8540,15 +8547,9 @@ end</script>
         end
       end
     end
-    local mapFeatureString = getMapUserData("mapFeatures")
-    if mapFeatureString then
-      local mapFeatures = yajl.to_value(mapFeatureString)
-      local message = "This room has the feature '%s'."
-      for mapFeature in pairs(mapFeatures) do
-        if getRoomUserData(num, "feature-" .. mapFeature) == "true" then
-          mmp.echo(string.format(message, mapFeature))
-        end
-      end
+    local message = "This room has the feature '%s'."
+    for _, mapFeature in pairs(mmp.getRoomMapFeatures(num)) do
+      mmp.echo(string.format(message, mapFeature))
     end
     -- actions we can do. This will be a short menu of sorts for actions
     mmp.echo("Stuff you can do:")
@@ -11052,11 +11053,11 @@ function mmp.roomCreateMapFeature(featureName, roomId)
     mmp.echo("Room number '" .. roomId .. "' does not exist.")
     return
   end
-	-- check if feature already exists
-	if getRoomUserData(roomId, "feature-" .. lowerFeatureName) == "true" then
-	  mmp.echo("Room '" .. roomId .. "' has already map feature '" .. lowerFeatureName .. "'.")
-		return
-	end
+  -- check if feature already exists
+  if table.contains(mmp.getRoomMapFeatures(roomId), lowerFeatureName) then
+    mmp.echo("Room '" .. roomId .. "' has already map feature '" .. featureName .. "'.")
+    return
+  end
   -- create map feature in room
   setRoomUserData(roomId, "feature-" .. lowerFeatureName, "true")
   mmp.echo(string.format("Map feature '%s' created in room number '%d'.", featureName, roomId))
@@ -11065,6 +11066,91 @@ function mmp.roomCreateMapFeature(featureName, roomId)
     setRoomChar(roomId, featureRoomChar)
     mmp.echo("The room now carries the room char '" .. featureRoomChar .. "'.")
   end
+end
+
+function mmp.roomDeleteMapFeature(featureName, roomId)
+  -- checks for the feature name
+  if not featureName then
+    mmp.echo("Which feature would you like to delete?")
+    return
+  end
+  local lowerFeatureName = featureName:lower()
+  -- checks for the room ID
+  if not roomId then
+    if not mmp.currentroom then
+      mmp.echo("Don't know where we are at the moment.")
+      return
+    end
+    roomId = mmp.currentroom
+  else
+    if type(roomId) ~= "number" then
+      mmp.echo("Need a room ID as number for deleting a map feature from a room.")
+      return
+    end
+  end
+  if not getRoomName(roomId) then
+    mmp.echo("Room number '" .. roomId .. "' does not exist.")
+    return
+  end
+  -- check if feature exists
+  local roomMapFeatures = mmp.getRoomMapFeatures(roomId)
+  if not table.contains(roomMapFeatures, lowerFeatureName) then
+    mmp.echo("Room '" .. roomId .. "' doesn't have map feature '" .. featureName .. "'.")
+    return
+  end
+  -- delete map feature from room
+  setRoomUserData(roomId, "feature-" .. lowerFeatureName, "")
+  mmp.echo(string.format("Map feature '%s' deleted from room number '%d'.", featureName, roomId))
+  -- now update room char if needed.
+  -- first update current map features of this room
+  roomMapFeatures = mmp.getRoomMapFeatures(roomId)
+  local mapFeatures = loadMapFeatures()
+  -- find out if we need to set a new room character
+  if getRoomChar(roomId) == mapFeatures[lowerFeatureName] then
+    local index, otherRoomMapFeature
+    -- find another usable room character
+    repeat
+      index, otherRoomMapFeature = next(roomMapFeatures, index)
+    until not otherRoomMapFeature or mapFeatures[otherRoomMapFeature] ~= ""
+    if otherRoomMapFeature then
+      -- we found a usable room character, now set it
+      local newRoomChar = mapFeatures[otherRoomMapFeature]
+      setRoomChar(roomId, newRoomChar)
+      mmp.echo("Using '" .. newRoomChar .. "' as new room character.")
+    else
+      -- we didn't find a usable room character, delete it.
+      setRoomChar(roomId, "")
+      mmp.echo("Deleted the current room character.")
+    end
+  end
+end
+
+function mmp.getRoomMapFeatures(roomId)
+  -- checks for the room ID
+  if not roomId then
+    if not mmp.currentroom then
+      mmp.echo("Don't know where we are at the moment.")
+      return
+    end
+    roomId = mmp.currentroom
+  else
+    if type(roomId) ~= "number" then
+      mmp.echo("Need a room ID as number for getting all map features of a room.")
+      return
+    end
+  end
+  if not getRoomName(roomId) then
+    mmp.echo("Room number '" .. roomId .. "' does not exist.")
+    return
+  end
+  local result = {}
+  local mapFeatures = loadMapFeatures()
+  for mapFeature in pairs(mapFeatures) do
+    if getRoomUserData(roomId, "feature-" .. mapFeature) == "true" then
+      result[#result + 1] = mapFeature
+    end
+  end
+  return result
 end</script>
 				<eventHandlerList />
 			</Script>

--- a/mudlet-mapper.xml
+++ b/mudlet-mapper.xml
@@ -6121,19 +6121,23 @@ function mmp.gotoAreaID(areaid, number, dashtype)
 end
 
 function mmp.gotoFeature(partialFeatureName, dashtype)
-  local userDataKeys = searchRoomUserData()
+  local mapFeatures = mmp.getMapFeatures()
   local feature
-  for _, key in pairs(userDataKeys) do
-    if key:starts("feature-") and key:find(partialFeatureName:lower()) then
-      feature = key
-      break
+  if mapFeatures[partialFeatureName:lower()] then
+    feature = partialFeatureName:lower()
+  else
+    for key in pairs(mapFeatures) do
+      if key:find(partialFeatureName:lower()) then
+        feature = key
+        break
+      end
     end
   end
   if not feature then
     mmp.echo("No feature like " .. partialFeatureName .. " found.")
     return
   end
-  local rooms = searchRoomUserData(feature, "true")
+  local rooms = searchRoomUserData("feature-" .. feature, "true")
   -- change the structure of the table so it fits getShortestOfMultipleRooms
   local possibleRooms = {}
   for _, room in pairs(rooms) do
@@ -11193,6 +11197,10 @@ function mmp.deleteMapFeature(featureName)
   saveMapFeatures(mapFeatures)
   mmp.echo("Deleted map feature '" .. featureName .. "' from map.")
   return true
+end
+
+function mmp.getMapFeatures()
+  return loadMapFeatures()
 end</script>
 				<eventHandlerList />
 			</Script>


### PR DESCRIPTION
This commit adds the initial support for the "goto feature <name> [gallop]"
command. If the map provides room user data with keys starting with "feature-",
this command will speedwalk to the closest with that user data. The optional
gallop part may be any of the supported gallop types.

Additional things missing to make this productive:
- [x] `feature create <name> [char <room char>]`
  - creates a new feature with the optionally given room character
  - features are saved in the map (room 1 user data)
- [x] `feature list`
  - lists all features including room characters
- [x] `room create feature [v<roomID>] <feature>` (`rcf [v<roomID>] <feature>`)
  - adds a feature to the room
  - sets room character and deletes previous set character
  - feature must come from `feature list`
- [x] add feature to `rl`
- [x] `room delete feature [v<roomID>] <feature>` (`rdf [v<roomID>] <feature>`)
  - if other features are still present, pick a random one for a new room character, if the character was from that feature
  - give feedback about the new room character used (`Using @ as new room character.`)
- [x] `feature delete <feature>`
  - removes feature and deletes feature from all rooms
- [x] ~taking over features from `gmcp.Room.Info.details`~ Not useful for now.
- [x] migration of room chars to features