### PR TITLE
Fixed the locateandechoside

### DIFF
--- a/mudlet-mapper.xml
+++ b/mudlet-mapper.xml
@@ -7102,7 +7102,7 @@ end
 function mmp.locateAndEchoSide(room, person)
   local t = mmp.searchRoomExact(room)
   echo("  (")
-  mmp.echonums(room, true)
+  mmp.echonums(room)
   echo(")")
   -- lowercase results
   for k, v in pairs(t) do


### PR DESCRIPTION
Fixed the locateAndEchoSide function. The argument was acting strange when all we were trying to do was just find the room number based on the name. Might have been left in there from when I was testing the script for the farsee change and adding that in. This will fix #111