### PR TITLE
Lusternia fixes

### DIFF
--- a/mudlet-mapper.xml
+++ b/mudlet-mapper.xml
@@ -1932,7 +1932,7 @@ raiseEvent("mmapper updated pdb")</script>
 						<integer>1</integer>
 					</regexCodePropertyList>
 				</Trigger>
-				<Trigger isActive="yes" isFolder="no" isTempTrigger="no" isMultiline="yes" isPerlSlashGOption="no" isColorizerTrigger="no" isFilterTrigger="no" isSoundTrigger="no" isColorTrigger="no" isColorTriggerFg="no" isColorTriggerBg="no">
+				<Trigger isActive="no" isFolder="no" isTempTrigger="no" isMultiline="yes" isPerlSlashGOption="no" isColorizerTrigger="no" isFilterTrigger="no" isSoundTrigger="no" isColorTrigger="no" isColorTriggerFg="no" isColorTriggerBg="no">
 					<name>Map artefact</name>
 					<script>mmp.gotoRoom(multimatches[4][2])</script>
 					<triggerType>0</triggerType>
@@ -10613,104 +10613,106 @@ end</script>
 					<Script isActive="yes" isFolder="no">
 						<name>Transverse and pathfind</name>
 						<packageName></packageName>
-						<script>local planes = {
-["the Prime Material Plane"]="prime",
-["the Ethereal Plane"]="ethereal",
-["the Water Elemental Plane"]="elemental",
-["the Earth Elemental Plane"]="elemental",
-["the Air Elemental Plane"]="elemental",
-["the Fire Elemental Plane"]="elemental",
-["Celestia, Plane of Light"]="cosmic",
-["the Cosmic Plane of Vortex"]="cosmic",
-["the Cosmic Plane of Continuum"]="cosmic",
-["the Tainted Plane of Nil"]="cosmic",
-["the Astral Plane"]="astral",
-}
+						<script>local planes =
+  {
+    ["the Prime Material Plane"] = "prime",
+    ["the Ethereal Plane"] = "ethereal",
+    ["the Water Elemental Plane"] = "elemental",
+    ["the Earth Elemental Plane"] = "elemental",
+    ["the Air Elemental Plane"] = "elemental",
+    ["the Fire Elemental Plane"] = "elemental",
+    ["Celestia, Plane of Light"] = "cosmic",
+    ["the Cosmic Plane of Vortex"] = "cosmic",
+    ["the Cosmic Plane of Continuum"] = "cosmic",
+    ["the Tainted Plane of Nil"] = "cosmic",
+    ["the Astral Plane"] = "astral",
+  }
 
 function mmp.transverse(_, command)
-	command = command:lower()
-	if command:sub(0,11)=="transverse " or command=="pathfind" then
-		transverseCMD = command
-		transversedFrom=gmcp.Room.Info.num
-		lastPlane = planes[gmcp.Room.Info.details[1]]
+  command = command:lower()
+  if command:sub(0, 11) == "transverse " or command == "pathfind" then
+    transverseCMD = command
+    transversedFrom = gmcp.Room.Info.num
+    lastPlane = planes[gmcp.Room.Info.details[1]]
     validTransverse = true
-	end
+  end
 end
-registerAnonymousEventHandler("sysDataSendRequest","mmp.transverse")
+
+registerAnonymousEventHandler("sysDataSendRequest", "mmp.transverse")
 
 function mmp.registerTransverseExit()
-	if transversedFrom~=gmcp.Room.Info.num then
-		addSpecialExit(transversedFrom,gmcp.Room.Info.num,transverseCMD)
-		setExitWeight(transversedFrom,transverseCMD,20)
-		if lastPlane then
-			addSpecialExit(gmcp.Room.Info.num,transversedFrom,"transverse "..lastPlane)
-			setExitWeight(gmcp.Room.Info.num,"transverse "..lastPlane,20)
-		end
+  if transversedFrom ~= gmcp.Room.Info.num then
+    addSpecialExit(transversedFrom, gmcp.Room.Info.num, transverseCMD)
+    setExitWeight(transversedFrom, transverseCMD, 20)
+    if lastPlane then
+      addSpecialExit(gmcp.Room.Info.num, transversedFrom, "transverse " .. lastPlane)
+      setExitWeight(gmcp.Room.Info.num, "transverse " .. lastPlane, 20)
+    end
     validTransverse = false
-	end
+  end
 end
 
 function mmp.clearTransverse()
-	local otherSide = 0
-	for room, command in pairs(getSpecialExits(gmcp.Room.Info.num)) do
-		if next(command)==transverseCMD then
-			otherSide=room
-		end
-	end
-	for room, command in pairs(getSpecialExits(otherSide) or {}) do
-		if room == gmcp.Room.Info.num and string.sub(next(command),0,11)=="transverse " then
-			removeSpecialExit(otherSide,next(command))
-		end
-	end
-	removeSpecialExit(gmcp.Room.Info.num,transverseCMD)
-	if mmp.autowalking then
-		mmp.autowalking = false
-		mmp.gotoRoom(string.split(next(mmp.showpathcache()),"_")[2])
-	end
+  local otherSide = 0
+  for room, command in pairs(getSpecialExits(gmcp.Room.Info.num)) do
+    if next(command) == transverseCMD then
+      otherSide = room
+    end
+  end
+  for room, command in pairs(getSpecialExits(otherSide) or {}) do
+    if room == gmcp.Room.Info.num and string.sub(next(command), 0, 11) == "transverse " then
+      removeSpecialExit(otherSide, next(command))
+    end
+  end
+  removeSpecialExit(gmcp.Room.Info.num, transverseCMD)
+  if mmp.autowalking then
+    mmp.autowalking = false
+    mmp.gotoRoom(string.split(next(mmp.showpathcache()), "_")[2])
+  end
 end
 
 function mmp.registerPathfind()
-	addSpecialExit(transversedFrom,gmcp.Room.Info.num,"pathfind")
-	setExitWeight(transversedFrom,"pathfind",15)
-	addSpecialExit(gmcp.Room.Info.num,transversedFrom,"pathfind")
-	setExitWeight(gmcp.Room.Info.num,"pathfind",15)
+  addSpecialExit(transversedFrom, gmcp.Room.Info.num, "pathfind")
+  setExitWeight(transversedFrom, "pathfind", 15)
+  addSpecialExit(gmcp.Room.Info.num, transversedFrom, "pathfind")
+  setExitWeight(gmcp.Room.Info.num, "pathfind", 15)
   validTransverse = false
 end
 
 function mmp.clearPathfind()
-	local otherSide = 0
-	for room, command in pairs(getSpecialExits(gmcp.Room.Info.num)) do
-		if next(command)=="pathfind" then
-			otherSide=room
-		end
-	end
-	for room, command in pairs(getSpecialExits(otherSide) or {}) do
-		if room == gmcp.Room.Info.num and next(command)=="pathfind" then
-			removeSpecialExit(otherSide,next(command))
-		end
-	end
-	removeSpecialExit(gmcp.Room.Info.num,"pathfind")
-	if mmp.autowalking then
-		mmp.autowalking = false
-		mmp.gotoRoom(string.split(next(mmp.showpathcache()),"_")[2])
-	end
+  local otherSide = 0
+  for room, command in pairs(getSpecialExits(gmcp.Room.Info.num)) do
+    if next(command) == "pathfind" then
+      otherSide = room
+    end
+  end
+  for room, command in pairs(getSpecialExits(otherSide) or {}) do
+    if room == gmcp.Room.Info.num and next(command) == "pathfind" then
+      removeSpecialExit(otherSide, next(command))
+    end
+  end
+  removeSpecialExit(gmcp.Room.Info.num, "pathfind")
+  if mmp.autowalking then
+    mmp.autowalking = false
+    mmp.gotoRoom(string.split(next(mmp.showpathcache()), "_")[2])
+  end
 end
 
 function mmp.lockpaths(lock)
-	local count=0
-	for area, areaname in pairs(mmp.areatabler) do
-		local rooms = getAreaRooms(area) or {}
-		for i = 0, #rooms do
-			local exits = getSpecialExits(rooms[i] or 0)
-			for room,command in pairs(exits or {}) do
-				if next(command)=="pathfind" then
-					count = count+1
-					lockSpecialExit(rooms[i],room,"pathfind",lock)
-				end
-			end
-		end
-	end
-	mmp.echo((lock and "Locked " or "Unlocked ")..count.." pathfinding exits.")
+  local count = 0
+  for area, areaname in pairs(mmp.areatabler) do
+    local rooms = getAreaRooms(area) or {}
+    for i = 0, #rooms do
+      local exits = getSpecialExits(rooms[i] or 0)
+      for room, command in pairs(exits or {}) do
+        if next(command) == "pathfind" then
+          count = count + 1
+          lockSpecialExit(rooms[i], room, "pathfind", lock)
+        end
+      end
+    end
+  end
+  mmp.echo((lock and "Locked " or "Unlocked ") .. count .. " pathfinding exits.")
 end</script>
 						<eventHandlerList />
 					</Script>

--- a/mudlet-mapper.xml
+++ b/mudlet-mapper.xml
@@ -1632,7 +1632,7 @@ mmp.pdb_lastupdate = {}</script>
 						<string>You snort and snuffle at the air, sensing through a ridiculous pig nose upon your face the faint traces of others in the surrounding area.</string>
 						<string>A pert little nose takes in a delicate whiff of your surroundings, sensing the faint traces of others in the nearby area.</string>
 						<string>You tilt back your head and inhale deeply through your nose, the whiskers of a wolf's snout upon your face twitching as you sense the faint traces of others in the surrounding area.</string>
-						<string>Your snout twitches and trembles at the air, sensing through a cute little rabbit nose upon your face the faint traces of others in the surrounding area.</string>
+						<string>You flutter your nose at the air, sensing through a cute little rabbit nose upon your face the faint traces of others in the surrounding area.</string>
 						<string>You sniff disdainfully at the air with a snobby snoot, wrinkling your nose as you sense the faint traces of others in the nearby area.</string>
 						<string>Your snout twitches and trembles at the air, sensing through a striped badger nose upon your face the faint traces of others in the surrounding area.</string>
 						<string>You twitch your snout and scent the air, sensing through a scaled fink nose upon your face the faint traces of others in the surrounding area.</string>
@@ -2479,7 +2479,9 @@ cecho("&lt;orange_red&gt;)")</script>
 					<Trigger isActive="yes" isFolder="no" isTempTrigger="no" isMultiline="no" isPerlSlashGOption="no" isColorizerTrigger="no" isFilterTrigger="no" isSoundTrigger="no" isColorTrigger="no" isColorTriggerFg="no" isColorTriggerBg="no">
 						<name>Succesful transverse</name>
 						<script>if mmp.game~= "lusternia" then return end
-mmp.registerTransverseExit()</script>
+if validTransverse then
+  mmp.registerTransverseExit()
+end</script>
 						<triggerType>0</triggerType>
 						<conditonLineDelta>0</conditonLineDelta>
 						<mStayOpen>0</mStayOpen>
@@ -2521,8 +2523,10 @@ mmp.clearTransverse()</script>
 					<Trigger isActive="yes" isFolder="no" isTempTrigger="no" isMultiline="no" isPerlSlashGOption="no" isColorizerTrigger="no" isFilterTrigger="no" isSoundTrigger="no" isColorTrigger="no" isColorTriggerFg="no" isColorTriggerBg="no">
 						<name>Succesful pathfind</name>
 						<script>if mmp.game~= "lusternia" then return end
-mmp.clearPathfind()
-mmp.registerPathfind()</script>
+if validTransverse then
+  mmp.clearPathfind()
+  mmp.registerPathfind()
+end</script>
 						<triggerType>0</triggerType>
 						<conditonLineDelta>0</conditonLineDelta>
 						<mStayOpen>0</mStayOpen>
@@ -10623,21 +10627,13 @@ end</script>
 ["the Astral Plane"]="astral",
 }
 
-local transverseCMD = transverseCMD
-local transversedFrom = transversedFrom
-local lastPlane = lastPlane
-function testytest()
-	echo(transversedFrom)
-	echo(transverseCMD)
-	echo(lastPlane)
-end
-
 function mmp.transverse(_, command)
 	command = command:lower()
 	if command:sub(0,11)=="transverse " or command=="pathfind" then
 		transverseCMD = command
 		transversedFrom=gmcp.Room.Info.num
 		lastPlane = planes[gmcp.Room.Info.details[1]]
+    validTransverse = true
 	end
 end
 registerAnonymousEventHandler("sysDataSendRequest","mmp.transverse")
@@ -10645,11 +10641,12 @@ registerAnonymousEventHandler("sysDataSendRequest","mmp.transverse")
 function mmp.registerTransverseExit()
 	if transversedFrom~=gmcp.Room.Info.num then
 		addSpecialExit(transversedFrom,gmcp.Room.Info.num,transverseCMD)
-		setExitWeight(transversedFrom,transverseCMD,10)
+		setExitWeight(transversedFrom,transverseCMD,20)
 		if lastPlane then
 			addSpecialExit(gmcp.Room.Info.num,transversedFrom,"transverse "..lastPlane)
-			setExitWeight(gmcp.Room.Info.num,"transverse "..lastPlane,10)
+			setExitWeight(gmcp.Room.Info.num,"transverse "..lastPlane,20)
 		end
+    validTransverse = false
 	end
 end
 
@@ -10674,9 +10671,10 @@ end
 
 function mmp.registerPathfind()
 	addSpecialExit(transversedFrom,gmcp.Room.Info.num,"pathfind")
-	setExitWeight(transversedFrom,"pathfind",6)
+	setExitWeight(transversedFrom,"pathfind",15)
 	addSpecialExit(gmcp.Room.Info.num,transversedFrom,"pathfind")
-	setExitWeight(gmcp.Room.Info.num,"pathfind",6)
+	setExitWeight(gmcp.Room.Info.num,"pathfind",15)
+  validTransverse = false
 end
 
 function mmp.clearPathfind()

--- a/mudlet-mapper.xml
+++ b/mudlet-mapper.xml
@@ -2502,7 +2502,8 @@ end</script>
 					<Trigger isActive="yes" isFolder="no" isTempTrigger="no" isMultiline="no" isPerlSlashGOption="no" isColorizerTrigger="no" isFilterTrigger="no" isSoundTrigger="no" isColorTrigger="no" isColorTriggerFg="no" isColorTriggerBg="no">
 						<name>Failed transverse</name>
 						<script>if mmp.game~= "lusternia" then return end
-mmp.clearTransverse()</script>
+mmp.clearTransverse()
+validTransverse = false</script>
 						<triggerType>0</triggerType>
 						<conditonLineDelta>0</conditonLineDelta>
 						<mStayOpen>0</mStayOpen>
@@ -2547,7 +2548,8 @@ end</script>
 					<Trigger isActive="yes" isFolder="no" isTempTrigger="no" isMultiline="no" isPerlSlashGOption="no" isColorizerTrigger="no" isFilterTrigger="no" isSoundTrigger="no" isColorTrigger="no" isColorTriggerFg="no" isColorTriggerBg="no">
 						<name>failed pathfind</name>
 						<script>if mmp.game~= "lusternia" then return end
-mmp.clearPathfind()</script>
+mmp.clearPathfind()
+validTransverse = false</script>
 						<triggerType>0</triggerType>
 						<conditonLineDelta>0</conditonLineDelta>
 						<mStayOpen>0</mStayOpen>


### PR DESCRIPTION
Added a check to rift/pathway triggers so exits aren't cleared and potential erroneous pathway exits aren't created when the game's inbuilt pathfinding is used instead of Mudlet's. Detecting these correctly will likely require game-side changes, so this was the best solution for now.
Rifts and pathways created by the mapper will now have weights of 20 and 15 respectively.
Removed a test function that didn't need to be around anymore.
Updated one of the scent trigger lines.