### PR TITLE
Add automatic opening for Manse doors in Lusternia

### DIFF
--- a/mudlet-mapper.xml
+++ b/mudlet-mapper.xml
@@ -3493,11 +3493,13 @@ mmp.echo("We're connected to Lithmeria.")</script>
 						<string>There is a door in the way, to the</string>
 						<string>There is a door in the way.</string>
 						<string>A closed door is in the way. You need to OPEN DOOR</string>
+						<string>There is an? (walnut|pine|oak|iron|reinforced steel) door in the way.</string>
 					</regexCodeList>
 					<regexCodePropertyList>
 						<integer>2</integer>
 						<integer>3</integer>
 						<integer>2</integer>
+						<integer>1</integer>
 					</regexCodePropertyList>
 				</Trigger>
 			</TriggerGroup>


### PR DESCRIPTION
This allows automatic opening of manse doors in Lusternia. Still doesn't close 'em behind you, but there are key sigils for that. Could also do a general `\w+` instead of the fixed set of door types to be adaptable for the future.