### PR TITLE
Stop speedwalk for gmcp.Room.WrongDir in StickMUD

### DIFF
--- a/mudlet-mapper.xml
+++ b/mudlet-mapper.xml
@@ -11058,6 +11058,33 @@ end</script>
 						</eventHandlerList>
 					</Script>
 				</Script>
+					<Script isActive="yes" isFolder="no">
+						<name>StickMUD</name>
+						<packageName></packageName>
+						<script>-------------------------------------------------
+--         Put your Lua functions here.        --
+--                                             --
+-- Note that you can also use external scripts --
+-------------------------------------------------
+</script>
+						<eventHandlerList />
+						<Script isActive="yes" isFolder="no">
+							<name>stickmud_stop_speedwalk_for_wrong_dir</name>
+							<packageName></packageName>
+							<script>function stickmud_stop_speedwalk_for_wrong_dir()
+  if mmp.game and mmp.game ~= "StickMUD" then
+    return
+  end
+  if #mmp.speedWalkPath &gt; 0 then
+    echo("The way \"" .. gmcp.Room.WrongDir .. "\" is blocked. Stopping speedwalk.")
+    mmp.stop()
+  end
+end</script>
+							<eventHandlerList>
+								<string>gmcp.Room.WrongDir</string>
+							</eventHandlerList>
+						</Script>
+					</Script>
 			</ScriptGroup>
 			<ScriptGroup isActive="yes" isFolder="yes">
 				<name>Test / one-time things</name>


### PR DESCRIPTION
The purpose of this game specific addition is to stop a speedwalk when the game is StickMUD and a Room.WrongDir GMCP event is triggered.  The typical use case for this is when an NPC is blocking the path, which is a common way we slow down newbies from entering areas that are too tough for them.  One could test this by trying to go to Demon World on the mapper in StickMUD.  You should stop at the Guard and could not go "in".

<img width="1155" alt="Screen Shot 2020-05-03 at 12 16 42 PM" src="https://user-images.githubusercontent.com/3058178/80919503-3bd94080-8d38-11ea-8370-a6bbc9961a3e.png">