### PR TITLE
Add some options to make the walker more reliable/accurate

### DIFF
--- a/mudlet-mapper.xml
+++ b/mudlet-mapper.xml
@@ -75,7 +75,7 @@
 					<integer>3</integer>
 				</regexCodePropertyList>
 			</Trigger>
-			<Trigger isActive="yes" isFolder="no" isTempTrigger="no" isMultiline="no" isPerlSlashGOption="no" isColorizerTrigger="yes" isFilterTrigger="no" isSoundTrigger="no" isColorTrigger="no" isColorTriggerFg="no" isColorTriggerBg="no">
+			<Trigger isActive="yes" isFolder="no" isTempTrigger="no" isMultiline="no" isPerlSlashGOption="no" isColorizerTrigger="no" isFilterTrigger="no" isSoundTrigger="no" isColorTrigger="no" isColorTriggerFg="no" isColorTriggerBg="no">
 				<name>Too quick</name>
 				<script>if mmp.autowalking then
   mmp.hasty = true

--- a/mudlet-mapper.xml
+++ b/mudlet-mapper.xml
@@ -75,9 +75,11 @@
 					<integer>3</integer>
 				</regexCodePropertyList>
 			</Trigger>
-			<Trigger isActive="yes" isFolder="no" isTempTrigger="no" isMultiline="no" isPerlSlashGOption="no" isColorizerTrigger="no" isFilterTrigger="no" isSoundTrigger="no" isColorTrigger="no" isColorTriggerFg="no" isColorTriggerBg="no">
+			<Trigger isActive="yes" isFolder="no" isTempTrigger="no" isMultiline="no" isPerlSlashGOption="no" isColorizerTrigger="yes" isFilterTrigger="no" isSoundTrigger="no" isColorTrigger="no" isColorTriggerFg="no" isColorTriggerBg="no">
 				<name>Too quick</name>
 				<script>if mmp.autowalking then
+  mmp.hasty = true
+  mmp.setmovetimer(0.5)
   mmp.deleteLineP()
 end</script>
 				<triggerType>0</triggerType>
@@ -1583,7 +1585,7 @@ end</script>
 						<integer>1</integer>
 					</regexCodePropertyList>
 				</Trigger>
-    				<Trigger isActive="yes" isFolder="no" isTempTrigger="no" isMultiline="no" isPerlSlashGOption="no" isColorizerTrigger="no" isFilterTrigger="no" isSoundTrigger="no" isColorTrigger="no" isColorTriggerFg="no" isColorTriggerBg="no">
+				<Trigger isActive="yes" isFolder="no" isTempTrigger="no" isMultiline="no" isPerlSlashGOption="no" isColorizerTrigger="no" isFilterTrigger="no" isSoundTrigger="no" isColorTrigger="no" isColorTriggerFg="no" isColorTriggerBg="no">
 					<name>Soulmark Scry</name>
 					<script>mmp.locateAndEcho(matches[3], matches[2])</script>
 					<triggerType>0</triggerType>
@@ -3548,6 +3550,8 @@ mmp.echo("We're connected to StickMUD.")</script>
 						<string>You push against the door in vain as you try to open it.</string>
 						<string>You do not have access to open this door.</string>
 						<string>The door beeps quietly. It appears to be locked.</string>
+						<string>This (walnut|pine|oak|iron|reinforced) door has been magically locked shut\.</string>
+						<string>You are not carrying a key for this (walnut|pine|oak|iron|reinforced) door\.</string>
 					</regexCodeList>
 					<regexCodePropertyList>
 						<integer>3</integer>
@@ -3556,6 +3560,8 @@ mmp.echo("We're connected to StickMUD.")</script>
 						<integer>3</integer>
 						<integer>3</integer>
 						<integer>3</integer>
+						<integer>1</integer>
+						<integer>1</integer>
 					</regexCodePropertyList>
 				</Trigger>
 				<Trigger isActive="yes" isFolder="no" isTempTrigger="no" isMultiline="no" isPerlSlashGOption="no" isColorizerTrigger="no" isFilterTrigger="no" isSoundTrigger="no" isColorTrigger="no" isColorTriggerFg="no" isColorTriggerBg="no">
@@ -3573,9 +3579,11 @@ mmp.echo("We're connected to StickMUD.")</script>
 					<colorTriggerBgColor>#000000</colorTriggerBgColor>
 					<regexCodeList>
 						<string>The door is locked.</string>
+						<string>The (walnut|pine|oak|iron|reinforced) door is locked\.</string>
 					</regexCodeList>
 					<regexCodePropertyList>
 						<integer>3</integer>
+						<integer>1</integer>
 					</regexCodePropertyList>
 				</Trigger>
 				<Trigger isActive="yes" isFolder="no" isTempTrigger="no" isMultiline="no" isPerlSlashGOption="no" isColorizerTrigger="no" isFilterTrigger="no" isSoundTrigger="no" isColorTrigger="no" isColorTriggerFg="no" isColorTriggerBg="no">
@@ -3846,7 +3854,8 @@ end
 local val = matches[4]
 if val == "true" or val == "yes" or val == "on" then val = true end
 if val == "false" or val == "no" or val == "off" then val = false end
-
+local numberVal = tonumber(val)
+val = numberVal and numberVal or val
 mmp.settings:setOption(matches[3], val)</script>
 				<command></command>
 				<packageName></packageName>
@@ -5390,7 +5399,7 @@ speedWalkCounter = 0
 mmp.speedWalk = mmp.speedWalk or {}
 mmp.speedWalkPath = mmp.speedWalkPath or {}
 mmp.speedWalkDir = mmp.speedWalkDir or {}
-local newversion = "developer"
+local newversion = "20.11.1"
 if mmp.version and mmp.version ~= newversion then
   if not mmp.game then
     mmp.echo(
@@ -5429,6 +5438,10 @@ function mmp.startup()
     )
   private_settings["showcmds"] =
     createOption(true, mmp.changeBoolFunc, {"boolean"}, "Show walking commands?")
+  private_settings["fastwalktime"] =
+    createOption(0.5, mmp.changeFastwalktime, {"number"}, "How often to send move command?")
+  private_settings["promptmove"] =
+    createOption(false, mmp.changePromptmove, {"boolean"}, "Move on prompt rather than gmcp event?")
   private_settings["slowwalk"] =
     createOption(
       false, mmp.setSlowWalk, {"boolean"}, "Walk slowly instead of as quick as possible?"
@@ -5952,12 +5965,13 @@ function mmp.setmovetimer(time)
   if mmp.movetimer then
     killTimer(mmp.movetimer)
   end
-  if mmp.settings.slowwalk then
+  if mmp.settings.slowwalk and not mmp.hasty then
     return
   end
+  time = time or mmp.settings.fastwalktime
   mmp.movetimer =
     tempTimer(
-      getNetworkLatency() + (time or 0.5),
+      getNetworkLatency() + time,
       function()
         mmp.movetimer = false
         mmp.move()
@@ -5987,7 +6001,7 @@ function mmp.move()
   if string.starts(cmd, "script:") then
     cmd = string.gsub(cmd, "script:", "")
     loadstring(cmd)()
-    if mmp.settings.showcmds then
+    if mmp.settings.showcmds and not mmp.hasty then
       cecho(
         string.format(
           "&lt;red&gt;(&lt;maroon&gt;%d - &lt;dark_slate_grey&gt;%s&lt;red&gt;)",
@@ -5996,9 +6010,10 @@ function mmp.move()
         )
       )
     end
+    mmp.hasty = false
   else
     send(cmd, false)
-    if mmp.settings.showcmds then
+    if mmp.settings.showcmds and not mmp.hasty then
       cecho(
         string.format(
           "&lt;red&gt;(&lt;maroon&gt;%d - &lt;dark_slate_grey&gt;%s&lt;red&gt;)",
@@ -6007,6 +6022,7 @@ function mmp.move()
         )
       )
     end
+    mmp.hasty = false
   end
 end
 
@@ -6275,10 +6291,18 @@ function speedwalking(event, num)
     mmp.autowalking = false
   elseif mmp.speedWalkPath[speedWalkCounter] == num then
     speedWalkCounter = speedWalkCounter + 1
-    mmp.move()
+    if mmp.settings.promptmove then
+      tempPromptTrigger(mmp.move, 1)
+    else
+      mmp.move()
+    end
   elseif mmp.game == "imperian" and madeflight then
     mmp.echo("We began flying!")
-    mmp.move()
+    if mmp.settings.promptmove then
+      tempPromptTrigger(mmp.move, 1)
+    else
+      mmp.move()
+    end
   elseif
     #mmp.speedWalkPath &gt; 0 and
     not mmp.ferry_rooms[num] and
@@ -8449,6 +8473,18 @@ end
 
 function mmp.changeEchoColour()
     mmp.echo("Now displaying echos in &lt;"..mmp.settings.echocolour.."&gt;"..mmp.settings.echocolour )
+end
+
+function mmp.changeFastwalktime()
+    mmp.echo(string.format("Fast walk timer now %.3f seconds.", mmp.settings.fastwalktime))
+end
+
+function mmp.changePromptmove()
+    if mmp.settings.promptmove then
+        mmp.echo("We will wait until we receive a prompt to send our movement commands!")
+        return
+    end
+    mmp.echo("We will send the movement command as soon as we get the Room.Info event!")
 end
 
 function mmp.lockPathways()

--- a/mudlet-mapper.xml
+++ b/mudlet-mapper.xml
@@ -6049,6 +6049,7 @@ function mmp.swim()
       )
     )
   end
+  mmp.hasty = true
   mmp.setmovetimer(2.5)
 end
 
@@ -6067,6 +6068,7 @@ function mmp.enterGrate()
       )
     )
   end
+  mmp.hasty = true
   mmp.setmovetimer(2.5)
 end
 
@@ -6093,6 +6095,7 @@ function mmp.openDoor()
       )
     )
   end
+  mmp.hasty = true
   mmp.setmovetimer(getNetworkLatency())
 end
 
@@ -6119,6 +6122,7 @@ function mmp.unlockDoor()
       )
     )
   end
+  mmp.hasty = true
   mmp.setmovetimer(getNetworkLatency())
 end
 

--- a/mudlet-mapper.xml
+++ b/mudlet-mapper.xml
@@ -2634,6 +2634,29 @@ validTransverse = false</script>
 						</regexCodePropertyList>
 					</Trigger>
 				</TriggerGroup>
+				<Trigger isActive="yes" isFolder="no" isTempTrigger="no" isMultiline="no" isPerlSlashGOption="no" isColorizerTrigger="no" isFilterTrigger="no" isSoundTrigger="no" isColorTrigger="no" isColorTriggerFg="no" isColorTriggerBg="no">
+					<name>Forced Movement</name>
+					<script>if mmp.autowalking then
+  mmp.hasty = true
+  mmp.setmovetimer(0.5)
+end</script>
+					<triggerType>0</triggerType>
+					<conditonLineDelta>0</conditonLineDelta>
+					<mStayOpen>0</mStayOpen>
+					<mCommand></mCommand>
+					<packageName></packageName>
+					<mFgColor>#ff0000</mFgColor>
+					<mBgColor>#ffff00</mBgColor>
+					<mSoundFile></mSoundFile>
+					<colorTriggerFgColor>#000000</colorTriggerFgColor>
+					<colorTriggerBgColor>#000000</colorTriggerBgColor>
+					<regexCodeList>
+						<string>The soft ground around you suddenly gives way and you find yourself sliding down a muddy embankment, ending up in an undignified heap on the floor of a dark chamber.</string>
+					</regexCodeList>
+					<regexCodePropertyList>
+						<integer>3</integer>
+					</regexCodePropertyList>
+				</Trigger>
 			</TriggerGroup>
 			<TriggerGroup isActive="yes" isFolder="yes" isTempTrigger="no" isMultiline="no" isPerlSlashGOption="no" isColorizerTrigger="no" isFilterTrigger="no" isSoundTrigger="no" isColorTrigger="no" isColorTriggerFg="no" isColorTriggerBg="no">
 				<name>Imperian</name>

--- a/mudlet-mapper.xml
+++ b/mudlet-mapper.xml
@@ -3573,8 +3573,8 @@ mmp.echo("We're connected to StickMUD.")</script>
 						<string>You push against the door in vain as you try to open it.</string>
 						<string>You do not have access to open this door.</string>
 						<string>The door beeps quietly. It appears to be locked.</string>
-						<string>This (walnut|pine|oak|iron|reinforced) door has been magically locked shut\.</string>
-						<string>You are not carrying a key for this (walnut|pine|oak|iron|reinforced) door\.</string>
+						<string>This (?:walnut|pine|oak|iron|reinforced) door has been magically locked shut\.</string>
+						<string>You are not carrying a key for this (?:walnut|pine|oak|iron|reinforced) door\.</string>
 					</regexCodeList>
 					<regexCodePropertyList>
 						<integer>3</integer>
@@ -3602,7 +3602,7 @@ mmp.echo("We're connected to StickMUD.")</script>
 					<colorTriggerBgColor>#000000</colorTriggerBgColor>
 					<regexCodeList>
 						<string>The door is locked.</string>
-						<string>The (walnut|pine|oak|iron|reinforced) door is locked\.</string>
+						<string>The (?:walnut|pine|oak|iron|reinforced) door is locked\.</string>
 					</regexCodeList>
 					<regexCodePropertyList>
 						<integer>3</integer>
@@ -3626,7 +3626,7 @@ mmp.echo("We're connected to StickMUD.")</script>
 						<string>There is a door in the way, to the</string>
 						<string>There is a door in the way.</string>
 						<string>A closed door is in the way. You need to OPEN DOOR</string>
-						<string>There is an? (walnut|pine|oak|iron|reinforced) door in the way.</string>
+						<string>There is an? (?:walnut|pine|oak|iron|reinforced) door in the way.</string>
 					</regexCodeList>
 					<regexCodePropertyList>
 						<integer>2</integer>
@@ -5443,7 +5443,7 @@ mmp.lagtable = {
         time = 10
     }
 }
-local newversion = "21.1.1"
+local newversion = "developer"
 if mmp.version and mmp.version ~= newversion then
   if not mmp.game then
     mmp.echo(
@@ -6010,7 +6010,8 @@ function mmp.setmovetimer(time)
   if mmp.settings.slowwalk and not mmp.hasty then
     return
   end
-  time = time or mmp.lagtable[mmp.settings.laglevel].time
+  local laglevel = mmp.settings.laglevel or 1
+  time = time or mmp.lagtable[laglevel].time
   mmp.movetimer =
     tempTimer(
       getNetworkLatency() + time,

--- a/mudlet-mapper.xml
+++ b/mudlet-mapper.xml
@@ -5399,7 +5399,7 @@ speedWalkCounter = 0
 mmp.speedWalk = mmp.speedWalk or {}
 mmp.speedWalkPath = mmp.speedWalkPath or {}
 mmp.speedWalkDir = mmp.speedWalkDir or {}
-local newversion = "20.11.1"
+local newversion = "21.1.1"
 if mmp.version and mmp.version ~= newversion then
   if not mmp.game then
     mmp.echo(

--- a/mudlet-mapper.xml
+++ b/mudlet-mapper.xml
@@ -5288,7 +5288,6 @@ function createOption(startingValue, onChangeFunc, allowedVarTypes, use, checkOp
 		use = use or "",
 		games = games,
 		checkOption = checkOption or function() return true end
-      
 	}
 
 	return option
@@ -5315,13 +5314,13 @@ function createOptionsTable(defaultTable)
 
 	function proxyTable:showAllOptions(game)
 		proxyTable.disp("Available options: \n")
-		for k, v in pairs(self[index]) do
+		for k, v in spairs(self[index]) do
 			if not game or not v.games or v.games[game] then
 				self.dispOption(k, v)
 			end
 		end
 		echo("\n")
-		for k, v in pairs(self["_customOptions"]) do
+		for k, v in spairs(self["_customOptions"]) do
 			self.dispOption(k, v)
 		end
 
@@ -5422,6 +5421,28 @@ speedWalkCounter = 0
 mmp.speedWalk = mmp.speedWalk or {}
 mmp.speedWalkPath = mmp.speedWalkPath or {}
 mmp.speedWalkDir = mmp.speedWalkDir or {}
+mmp.lagtable = {
+    [1] = {
+        description = "Normal, default level.",
+        time = 0.5
+    },
+    [2] = {
+        description = "Decent, but slightly laggy.",
+        time = 1
+    },
+    [3] = {
+        description = "Noticably laggy with occasional spikes.",
+        time = 2
+    },
+    [4] = {
+        description = "Bad. Terrible. Terribad.",
+        time = 5
+    },
+    [5] = {
+        description = "Carrier Pigeon",
+        time = 10
+    }
+}
 local newversion = "21.1.1"
 if mmp.version and mmp.version ~= newversion then
   if not mmp.game then
@@ -5461,10 +5482,8 @@ function mmp.startup()
     )
   private_settings["showcmds"] =
     createOption(true, mmp.changeBoolFunc, {"boolean"}, "Show walking commands?")
-  private_settings["fastwalktime"] =
-    createOption(0.5, mmp.changeFastwalktime, {"number"}, "How often to send move command?")
-  private_settings["promptmove"] =
-    createOption(false, mmp.changePromptmove, {"boolean"}, "Move on prompt rather than gmcp event?")
+  private_settings["laglevel"] =
+    createOption(1, mmp.changeLaglevel, {"number"}, "How laggy is your connection, (fast 1&lt;-&gt;5 slow)?", mmp.verifyLaglevel)
   private_settings["slowwalk"] =
     createOption(
       false, mmp.setSlowWalk, {"boolean"}, "Walk slowly instead of as quick as possible?"
@@ -5991,7 +6010,7 @@ function mmp.setmovetimer(time)
   if mmp.settings.slowwalk and not mmp.hasty then
     return
   end
-  time = time or mmp.settings.fastwalktime
+  time = time or mmp.lagtable[mmp.settings.laglevel].time
   mmp.movetimer =
     tempTimer(
       getNetworkLatency() + time,
@@ -6318,18 +6337,10 @@ function speedwalking(event, num)
     mmp.autowalking = false
   elseif mmp.speedWalkPath[speedWalkCounter] == num then
     speedWalkCounter = speedWalkCounter + 1
-    if mmp.settings.promptmove then
-      tempPromptTrigger(mmp.move, 1)
-    else
-      mmp.move()
-    end
+    tempPromptTrigger(mmp.move, 1)
   elseif mmp.game == "imperian" and madeflight then
     mmp.echo("We began flying!")
-    if mmp.settings.promptmove then
-      tempPromptTrigger(mmp.move, 1)
-    else
-      mmp.move()
-    end
+    tempPromptTrigger(mmp.move, 1)
   elseif
     #mmp.speedWalkPath &gt; 0 and
     not mmp.ferry_rooms[num] and
@@ -6407,7 +6418,8 @@ function doSpeedWalk(dashtype)
     echo(": ")
     speedWalkCounter = 1
     if mmp.canmove() then
-      mmp.move()
+      mmp.hasty = true
+      mmp.setmovetimer(0.1)
     else
       echo("(when we get balance back / aren't hindered)")
     end
@@ -8502,16 +8514,15 @@ function mmp.changeEchoColour()
     mmp.echo("Now displaying echos in &lt;"..mmp.settings.echocolour.."&gt;"..mmp.settings.echocolour )
 end
 
-function mmp.changeFastwalktime()
-    mmp.echo(string.format("Fast walk timer now %.3f seconds.", mmp.settings.fastwalktime))
+function mmp.changeLaglevel()
+    local laglevel = mmp.settings.laglevel
+    local laginfo = mmp.lagtable[laglevel]
+    mmp.echo(string.format("Lag level set to [%d]: %s (%ss timer)", laglevel, laginfo.description, tostring(laginfo.time)))
 end
 
-function mmp.changePromptmove()
-    if mmp.settings.promptmove then
-        mmp.echo("We will wait until we receive a prompt to send our movement commands!")
-        return
-    end
-    mmp.echo("We will send the movement command as soon as we get the Room.Info event!")
+function mmp.verifyLaglevel(value)
+  if mmp.lagtable[value] then return true end
+  return false
 end
 
 function mmp.lockPathways()


### PR DESCRIPTION
## Purpose of change

Add a bit of configurability, and make slowwalk less useless. 
Shift movement to prompt trigger to ensure all information for a room has come in before moving.
Right now, `mconfig slowwalk on` fails movement any time it hits a too hasty message, needs to open a door, or anything else tries to set a timer for the next movement piece, for any reason.

Whereas I feel like it's really about not spamming the server with movement commands constantly. I have created a compromise of sorts

## More detailed list of changes

I'm sorry that this kind of touches on several things, but they were all kind of related and were tested together.

* Adjusts the event handler for Room.Info to instantiate a 1 time prompt trigger to do the actual movement. This ensures that all requisite events for a room have come in and been able to be acted upon before movement is actually sent to the game. This makes it easier to tell the autowalk to stop based on conditions in Char.Items.List for instance.
* `mconfig slowwalk on` now prevents the overall failback timer which currently spams the movement command every half second (+previous latency). This prevents sending any extra movement commands based purely on timer.
  * unlike before, however, slowwalk does not prevent it from attempting to resend the command after a "don't be too hasty" message, or in places where setmovetimer() is being used to try movement again (doors, too hasty messages, other failure conditions)
* adds `mconfig laglevel <1-5>` to adjust the time used for the failsafe timer used to resend commands if the movement has not yet succeeded. `mconfig laglevel 1` is the default and uses the current 0.5 second timer.
![image](https://user-images.githubusercontent.com/3660/103470968-bafb9a00-4d47-11eb-803b-b620ab7f55c5.png)

* fixes `mconfig` alias to allow for setting number values and having their types be guarded like string/booleans are
* fixes `mconfig` to display options in alphabetical order by moving to spairs instead of pairs to the display.
* adds patterns for doors which were previously missing and causing the mapper to get hung up in Lusternia (but doors are listed in a separate group so put it there)
* adds a forced movement pattern I discovered in Lusternia while testing the autowalker with slowwalk on in Serenwilde in Lusternia

## Testing done

In none of these games do I really own or use travel artefacts. 

Also, there may be cases where stop conditions are not being cleanly handled now but glossed over by the failsafe timer spam. 

All were tested with slowwalk on.

The most testing was done on Lusternia, as it's the game I know best and am currently most active in.

* Achaea
  * Run from Savannah to Cyrene for food, and back to the Savannah. Seemed to work well overall, no accidental stoppages, stopped on all the mobs it was meant to stop on
* Lusternia
  * extensive testing in and around Serenwilde and some in Gaudiguch. 100% accuracy with stopping.
* Aetolia
  * Tested with a new character in the tutorial zone. No issues but not exactly extensive either
* Imperian
  * Tested in... Khandava I think it was? I found an old character. Had issues with doors but they were issues the current mapper has as well
* Starmoun
  * Tested around Reynolds Station and New Haven. Still moved around properly, did not get caught on using transports or anything like that.

The testing above was done when laglevel was fastmovetime and settable to an arbitrary number, and when the shift to doing the movement on the prompt was still optional. (sha a69e82f). It was retested again on Lusternia with the same level of use as it was above with the current version (sha f623413).