### PR TITLE
Add JSON support

### DIFF
--- a/mudlet-mapper.xml
+++ b/mudlet-mapper.xml
@@ -4915,53 +4915,91 @@ end</script>
 			</Alias>
 			<Alias isActive="yes" isFolder="no">
 				<name>Save a map</name>
-				<script>local function s(loc)
-    if not saveMap(loc) then
-      mmp.echo("Couldn't save the map :(")
-    else
-      if loc ~= "" then mmp.echo("Map saved.") else mmp.echo("Saved the default map.") end
-    end
+				<script>local function s(location, format)
+  local savednormal, savedjson = "not saved", "not saved"
+  if format == "json" then
+    savedjson = saveJsonMap(location)
+  elseif format == "all" then
+    savednormal = saveMap(location)
+    savedjson = saveJsonMap(location)
+  elseif format == nil or format == "" then
+    savednormal = saveMap(location)
+  end
+  
+  if savednormal == nil then
+    mmp.echo("Couldn't save the map :(")
+  elseif savednormal == true then
+    mmp.echo(loc ~= "" and "Map saved." or "Saved the default map.")
+  end
+  if savedjson == nil then
+    mmp.echo("Couldn't save the JSON map :(")
+  elseif savedjson == true then
+    mmp.echo(loc ~= "" and "Map saved in JSON." or "Saved the default map in JSON.")
+  end
 end
 
-if not saveMap then
-  mmp.echo("Your Mudlet can't save maps. Please upgrade it!")
+if matches[2] and (matches[2] == "json" or matches[2] == "all") and not saveJsonMap then
+  mmp.echo("Your Mudlet can't save maps in JSON, please upgrade first.")
+  return
+end
+if matches[3] and matches[3] == "custom" then
+  s(
+    invokeFileDialog(false, "Please select the folder to save the map in and hit Open") ..
+    "/Mudlet map from " ..
+    os.date("%A %d, %b '%y") ..
+    ".dat",
+    matches[2]
+  )
+elseif matches[3] then
+  s(getMudletHomeDir() .. "/map/" .. matches[3], matches[2])
 else
-  if matches[2] and matches[2] == "custom" then
-    s(invokeFileDialog(false, "Please select the folder to save the map in and hit Open").."/Mudlet map from "..os.date("%A %d, %b '%y")..".dat")
-  elseif matches[2] then
-	s(getMudletHomeDir().."/map/"..matches[2])
-  else
-    s("")
-  end
+  s("", matches[2])
 end</script>
 				<command></command>
 				<packageName></packageName>
-				<regex>^map save(?: (.+))?$</regex>
+				<regex>^map save(?: (json|all))?(?: (.+))?$</regex>
 			</Alias>
 			<Alias isActive="yes" isFolder="no">
 				<name>Load a map</name>
 				<script>local function s(loc)
-    if not loadMap(loc) then
-      mmp.echo("Couldn't load the map :(")
+  if string.ends(loc, ".json") and not loadJsonMap then
+    mmp.echo("Your Mudlet can't load maps in JSON, please upgrade first.")
+    return
+  end
+  
+  local allok = true
+  if string.ends(loc, ".json") then
+    allok = loadJsonMap(loc)
+  else
+    allok = loadMap(loc)
+  end
+  
+  if not allok then
+    mmp.echo("Couldn't load the map :(")
+  else
+    mmp.lockWormholes();
+    mmp.lockSewers();
+    mmp.lockPebble();
+    if mmp.settings.waterwalk then
+      mmp.enableWaterWalk()
     else
-      mmp.lockWormholes(); mmp.lockSewers(); mmp.lockPebble();
-      if mmp.settings.waterwalk then mmp.enableWaterWalk() else mmp.disableWaterWalk() end
-
-      if loc ~= "" then mmp.echo("Map loaded.") else mmp.echo("Loaded the default map.") end
-      raiseEvent("mmapper updated map")
+      mmp.disableWaterWalk()
     end
+    if loc ~= "" then
+      mmp.echo("Map loaded.")
+    else
+      mmp.echo("Loaded the default map.")
+    end
+    raiseEvent("mmapper updated map")
+  end
 end
 
-if not loadMap then
-  mmp.echo("Your Mudlet can't load maps. Please upgrade it!")
+if matches[2] and matches[2] == "custom" then
+  s(invokeFileDialog(true, "Please select the map file and click Open to load it"))
+elseif matches[2] then
+  s(getMudletHomeDir() .. "/map/" .. matches[2])
 else
-  if matches[2] and matches[2] == "custom" then
-    s(invokeFileDialog(true, "Please select the map file and click Open to load it"))
-  elseif matches[2] then
-	s(getMudletHomeDir().."/map/"..matches[2])
-  else
-    s("")
-  end
+  s("")
 end</script>
 				<command></command>
 				<packageName></packageName>

--- a/mudlet-mapper.xml
+++ b/mudlet-mapper.xml
@@ -4929,12 +4929,12 @@ end</script>
   if savednormal == nil then
     mmp.echo("Couldn't save the map :(")
   elseif savednormal == true then
-    mmp.echo(loc ~= "" and "Map saved." or "Saved the default map.")
+    mmp.echo(location ~= "" and "Map saved." or "Saved the default map.")
   end
   if savedjson == nil then
     mmp.echo("Couldn't save the JSON map :(")
   elseif savedjson == true then
-    mmp.echo(loc ~= "" and "Map saved in JSON." or "Saved the default map in JSON.")
+    mmp.echo(location ~= "" and "Map saved in JSON." or "Saved the default map in JSON.")
   end
 end
 


### PR DESCRIPTION
# map save - save the map

Use: \*map save \<optional name\>\* will save all of the map. Sample use:

    default map - ie 'map save' will save the map with the default name as the latest one
    map name - ie 'map save map before experiment' will save the map with that name
    custom - ie 'map save custom' will export the map as a file, so you can share it with others

You can also save the map as text (JSON) by using `map save json` or `map save all` (in both normal and JSON). For example:

    default map - ie 'map save json' will save the map with the default name as the latest one, 'map save all' will do it in both.
    map name - ie 'map save json map before experiment' will save the map with that name
    custom - ie 'map save json custom' will export the map as a file, so you can share it with others

# map load - load the map

Use: \*map load \<optional name\>\* will reload the map. Sample use:

    default map - ie 'map load' will load the latest saved map (it may be a named one)
    map name - ie 'map load before experiment' will load the map with that name
    custom - ie 'map load custom' will load a map .dat file as you select it
    as json - 'map load before experiment.json' - appending '.json' will make it load as json