### PR TITLE
Save binary map last, so it'll be the first to load

### DIFF
--- a/mudlet-mapper.xml
+++ b/mudlet-mapper.xml
@@ -4920,8 +4920,8 @@ end</script>
   if format == "json" then
     savedjson = saveJsonMap(location)
   elseif format == "all" then
-    savednormal = saveMap(location)
     savedjson = saveJsonMap(location)
+    savednormal = saveMap(location)
   elseif format == nil or format == "" then
     savednormal = saveMap(location)
   end


### PR DESCRIPTION
When using `map save all`, save the JSON first and then the binary map after, so it'll be the binary map that will be the first to load in case Mudlet is restarted. The binary map is much, much quicker to load than the JSON one.