### PR TITLE
Added the code for spairs to ensure compatibility with older mudlet versions.

### DIFF
--- a/mudlet-mapper.xml
+++ b/mudlet-mapper.xml
@@ -5343,13 +5343,13 @@ function createOptionsTable(defaultTable)
 
 	function proxyTable:showAllOptions(game)
 		proxyTable.disp("Available options: \n")
-		for k, v in spairs(self[index]) do
+		for k, v in pairs(self[index]) do
 			if not game or not v.games or v.games[game] then
 				self.dispOption(k, v)
 			end
 		end
 		echo("\n")
-		for k, v in spairs(self["_customOptions"]) do
+		for k, v in pairs(self["_customOptions"]) do
 			self.dispOption(k, v)
 		end
 

--- a/mudlet-mapper.xml
+++ b/mudlet-mapper.xml
@@ -5299,6 +5299,23 @@ mmp.echo("All astral nodes have been "..(matches[2]:lower()=="on" and "" or "un"
 --                                             --
 -- Note that you can also use external Scripts --
 -------------------------------------------------
+local spairs = spairs or function(tbl, order)
+  local keys = table.keys(tbl)
+  if order then
+    table.sort(keys, function(a,b) return order(tbl, a, b) end)
+  else
+    table.sort(keys)
+  end
+
+  local i = 0
+  return function()
+    i = i + 1
+    if keys[i] then
+      return keys[i], tbl[keys[i]]
+    end
+  end
+end
+
 
 function createOption(startingValue, onChangeFunc, allowedVarTypes, use, checkOption, games)
 	if allowedVarTypes then -- make sure our starting Value follows type rules
@@ -5343,13 +5360,13 @@ function createOptionsTable(defaultTable)
 
 	function proxyTable:showAllOptions(game)
 		proxyTable.disp("Available options: \n")
-		for k, v in pairs(self[index]) do
+		for k, v in spairs(self[index]) do
 			if not game or not v.games or v.games[game] then
 				self.dispOption(k, v)
 			end
 		end
 		echo("\n")
-		for k, v in pairs(self["_customOptions"]) do
+		for k, v in spairs(self["_customOptions"]) do
 			self.dispOption(k, v)
 		end
 


### PR DESCRIPTION
The option table script would produce errors on mudlet versions prior to 4.10 due to its use of the spairs function. Including the code for Spairs helps with compatibility.