### PR TITLE
Added three new environments to the lusternia envid table

### DIFF
--- a/mudlet-mapper.xml
+++ b/mudlet-mapper.xml
@@ -10636,6 +10636,7 @@ end</script>
     ["constructed underground"] = 2,
     ["deep ocean"]              = 24,
     ["natural underground"]     = 3,
+    ["constructed underwater"]  = 41,
     aether                      = 36,
     astral                      = 35,
     beach                       = 5,
@@ -10670,6 +10671,8 @@ end</script>
     valley                      = 13,
     volcanic                    = 32,
     wasteland                   = 29,
+    badlands                    = 40,
+    wetlands                    = 31,
   }
 
   mmp.waterenvs = {}


### PR DESCRIPTION
The table was missing constructed underwater, wetlands, and badlands, which caused issues when trying to map areas with those environments. The IDs correspond to the environments in the mmp xmls provided by the game.