### PR TITLE
Disable orb of confinement trigger

### DIFF
--- a/mudlet-mapper.xml
+++ b/mudlet-mapper.xml
@@ -1606,9 +1606,11 @@ end</script>
 						<integer>1</integer>
 					</regexCodePropertyList>
 				</Trigger>
-				<Trigger isActive="yes" isFolder="no" isTempTrigger="no" isMultiline="yes" isPerlSlashGOption="no" isColorizerTrigger="no" isFilterTrigger="no" isSoundTrigger="no" isColorTrigger="no" isColorTriggerFg="no" isColorTriggerBg="no">
+				<Trigger isActive="no" isFolder="no" isTempTrigger="no" isMultiline="yes" isPerlSlashGOption="no" isColorizerTrigger="no" isFilterTrigger="no" isSoundTrigger="no" isColorTrigger="no" isColorTriggerFg="no" isColorTriggerBg="no">
 					<name>City has orb of confinement</name>
-					<script>local orbTable = mmp.getAchaeaOrbTable()
+					<script> -- disabled since the orb is now an rng chance and not a 100% blocker
+
+local orbTable = mmp.getAchaeaOrbTable()
 local areaID = getRoomArea(mmp.currentroom) or 0
 if areaID == 0 or mmp.game ~= "achaea" then
   return


### PR DESCRIPTION
Per discussion in Achaea, this is now an rng chance and people prefer the mapper to keep trying anyway.

You can still manually set the orb options per-city if you'd like not to have it keep trying.