### PR TITLE
Minor bugfixes

### DIFF
--- a/mudlet-mapper.xml
+++ b/mudlet-mapper.xml
@@ -5788,7 +5788,7 @@ function mmp.startup()
   private_settings["twist"] = createOption(false, mmp.changeBoolFunc, {"boolean"}, "Make use of your Mt. Dio Bix?", nil, {lusternia = true})
   private_settings["figurine"] = createOption(false, mmp.changeBoolFunc, {"boolean"}, "Make use of your Icewynd Bix?", nil, {lusternia = true})
   private_settings["periscope"] = createOption(false, mmp.changeBoolFunc, {"boolean"}, "Make use of your Aquagoria Bix?", nil, {lusternia = true})
-  private_settings["pebble"] = createOption(false, mmp.changeBoolFunc, {"boolean"}, "Make use of your Lyraa Bix?", nil, {lusternia = true})
+  private_settings["lyraa"] = createOption(false, mmp.changeBoolFunc, {"boolean"}, "Make use of your Lyraa Bix?", nil, {lusternia = true})
   private_settings["shard"] = createOption(false, mmp.changeBoolFunc, {"boolean"}, "Make use of your Xion Bix?", nil, {lusternia = true})
   private_settings["tibia"] = createOption(false, mmp.changeBoolFunc, {"boolean"}, "Make use of your Cankermore Bix?", nil, {lusternia = true})
   private_settings["mud"] = createOption(false, mmp.changeBoolFunc, {"boolean"}, "Make use of your Mucklemarsh Bix?", nil, {lusternia = true})
@@ -10509,7 +10509,7 @@ function mmp.orbed(roomID)
   --first table is the areas in the city for the crowdmap, second is for the game provided map.
   local areaID = getRoomArea(roomID or mmp.currentroom)
   for city, areaTable in pairs(orbTable) do
-    if table.contains(areaTable, areaID) then
+    if table.index_of(areaTable, areaID) then
       return mmp.settings["orb" .. city]
     end
   end

--- a/mudlet-mapper.xml
+++ b/mudlet-mapper.xml
@@ -7324,7 +7324,7 @@ function mmp.addWingsLusternia()
       {setting = "twist", item = "diobix", room = 18203, areas = {"Mount Dio"}},
       {setting = "snowglobe", item = "treebix", room = 10992, areas = {"the Great Spirit Tree"}},
       {setting = "periscope", item = "aquabix", room = 36073, areas = {"Aquagoria"}},
-      {setting = "pebble", item = "lyraabix", room = 33825, areas = {"Lyraa Ey Rielys"}},
+      {setting = "lyraa", item = "lyraabix", room = 33825, areas = {"Lyraa Ey Rielys"}},
       {setting = "shard", item = "xionbix", room = 12652, areas = {"the Workshop of Xion"}},
       {setting = "cookie", item = "crumbix", room = 9888, areas = {"Crumkindivia"}},
       {setting = "wheel", item = "drambix", room = 10509, areas = {"the Dramube Triangle"}},


### PR DESCRIPTION
Renamed the Lyraa bix's mconfig from pebble to lyraa to avoid conflict with the achaea pebble. Changed the Achaea orb of confinement script to use table.index_of instead of table.contains to prevent some low areaID areas like New Thera from being considered 'orbed'.