### PR TITLE
Fix: Speedwalk won't stop for StickMUD

### DIFF
--- a/mudlet-mapper.xml
+++ b/mudlet-mapper.xml
@@ -11501,7 +11501,7 @@ end</script>
 						<name>mmp.stickmudStopSpeedwalkForWrongDir</name>
 						<packageName></packageName>
 						<script>function mmp.stickmudStopSpeedwalkForWrongDir()
-  if mmp.game and mmp.game ~= "StickMUD" then
+  if mmp.game and mmp.game ~= "stickmud" then
     return
   end
   if #mmp.speedWalkPath &gt; 0 then


### PR DESCRIPTION
Discovered that speedwalking won't stop upon a gmcp.Room.WrongDir event due to mmp.game being all lower case.