### PR TITLE
Add support for games that operate on hashes

### DIFF
--- a/mudlet-mapper.xml
+++ b/mudlet-mapper.xml
@@ -10240,7 +10240,14 @@ end
 					<packageName></packageName>
 					<script>function mmp.centerRoominfo()
   -- lusternia has gmcp.Room.Players before gmcp.Room.Info is created
-  if gmcp.Room.Info then centerview(gmcp.Room.Info.num) end
+  if gmcp.Room.Info then
+    if gmcp.Room.Info.num then
+      centerview(gmcp.Room.Info.num)
+    elseif gmcp.Room.Info.roomhash then
+    print(tostring(mmp.roomidFromHash(gmcp.Room.Info.roomhash)))
+      centerview(mmp.roomidFromHash(gmcp.Room.Info.roomhash))
+    end
+  end
 end</script>
 					<eventHandlerList>
 						<string>gmcp.Room</string>
@@ -10348,13 +10355,15 @@ local function getshiftedcoords(original, ox, oy, oz)
 end
 
 -- returns (and creates if needed) a room ID for a given hash
-function mmp.obtainHash(hash)
+function mmp.roomidFromHash(hash)
   local id = getRoomIDbyHash(hash)
   if id == -1 then 
     id = createRoomID()
     addRoom(id)
     setRoomIDbyHash(id, hash)
   end
+  
+  return id
 end
 
 function mmp.mappingNewroom(_, num)
@@ -10380,7 +10389,7 @@ function mmp.mappingNewroom(_, num)
           getRoomName, getRoomCoordinates, getRoomsByPosition
         local num = tonumber(num) or tonumber(gmcp.Room.Info.num)
         if not num and gmcp.Room.Info.roomhash then
-          num = mmp.obtainHash(gmcp.Room.Info.roomhash)
+          num = mmp.roomidFromHash(gmcp.Room.Info.roomhash)
         end
         local currentexits = gmcp.Room.Info.exits
         local s = ""
@@ -10392,7 +10401,7 @@ function mmp.mappingNewroom(_, num)
               if gmcp.Room.Info.roomhash then
                 -- in a hash-based game, the 'id' is actually a hash, not an id
                 -- turn it into a proper id:
-                id = mmp.obtainHash(id)
+                id = mmp.roomidFromHash(id)
               end
               
               if mmp.roomexists(id) then
@@ -10420,6 +10429,12 @@ function mmp.mappingNewroom(_, num)
             local x = getRoomExits(num) or {}
             -- check for missing exits
             for exit, id in pairs(currentexits) do
+              if gmcp.Room.Info.roomhash then
+                -- in a hash-based game, the 'id' is actually a hash, not an id
+                -- turn it into a proper id:
+                id = mmp.roomidFromHash(id)
+              end
+              
               if id == 0 then
                 s =
                   s ..

--- a/mudlet-mapper.xml
+++ b/mudlet-mapper.xml
@@ -2005,6 +2005,43 @@ raiseEvent("mmapper updated pdb")</script>
 				</Trigger>
 			</TriggerGroup>
 			<TriggerGroup isActive="yes" isFolder="yes" isTempTrigger="no" isMultiline="no" isPerlSlashGOption="no" isColorizerTrigger="no" isFilterTrigger="no" isSoundTrigger="no" isColorTrigger="no" isColorTriggerFg="no" isColorTriggerBg="no">
+				<name>Astaria</name>
+				<script></script>
+				<triggerType>0</triggerType>
+				<conditonLineDelta>0</conditonLineDelta>
+				<mStayOpen>0</mStayOpen>
+				<mCommand></mCommand>
+				<packageName></packageName>
+				<mFgColor>#ff0000</mFgColor>
+				<mBgColor>#ffff00</mBgColor>
+				<mSoundFile></mSoundFile>
+				<colorTriggerFgColor>#000000</colorTriggerFgColor>
+				<colorTriggerBgColor>#000000</colorTriggerBgColor>
+				<regexCodeList />
+				<regexCodePropertyList />
+				<Trigger isActive="yes" isFolder="no" isTempTrigger="no" isMultiline="no" isPerlSlashGOption="no" isColorizerTrigger="no" isFilterTrigger="no" isSoundTrigger="no" isColorTrigger="no" isColorTriggerFg="no" isColorTriggerBg="no">
+					<name>Login</name>
+					<script>raiseEvent("mmp logged in", "Astaria")
+mmp.game = "astaria"</script>
+					<triggerType>0</triggerType>
+					<conditonLineDelta>0</conditonLineDelta>
+					<mStayOpen>0</mStayOpen>
+					<mCommand></mCommand>
+					<packageName></packageName>
+					<mFgColor>#ff0000</mFgColor>
+					<mBgColor>#ffff00</mBgColor>
+					<mSoundFile></mSoundFile>
+					<colorTriggerFgColor>#000000</colorTriggerFgColor>
+					<colorTriggerBgColor>#000000</colorTriggerBgColor>
+					<regexCodeList>
+						<string>                         The Kingdom of Astaria</string>
+					</regexCodeList>
+					<regexCodePropertyList>
+						<integer>3</integer>
+					</regexCodePropertyList>
+				</Trigger>
+			</TriggerGroup>
+			<TriggerGroup isActive="yes" isFolder="yes" isTempTrigger="no" isMultiline="no" isPerlSlashGOption="no" isColorizerTrigger="no" isFilterTrigger="no" isSoundTrigger="no" isColorTrigger="no" isColorTriggerFg="no" isColorTriggerBg="no">
 				<name>Asteria</name>
 				<script></script>
 				<triggerType>0</triggerType>
@@ -10604,7 +10641,6 @@ function mmp.mappingNewroom(_, num)
         end
         if #s &gt; 0 then
           mmp.echo(s)
-          mmp.debug(tostring(mmp.currentroom))
           centerview(mmp.currentroom)
         end
       end,
@@ -11871,6 +11907,104 @@ end</script>
 end</script>
 						<eventHandlerList>
 							<string>gmcp.Room.WrongDir</string>
+						</eventHandlerList>
+					</Script>
+				</Script>
+				<Script isActive="yes" isFolder="no">
+					<name>Astaria</name>
+					<packageName></packageName>
+					<script></script>
+					<eventHandlerList />
+					<Script isActive="yes" isFolder="no">
+						<name>mmp.registerAstariasEnvData</name>
+						<packageName></packageName>
+						<script>function mmp.registerAstariasEnvData(_, game)
+  if game ~= "Astaria" then return end
+  mmp.envids =
+  {
+    ["field"]                   = 3,
+    -- old ones below
+    ["a sheltered dell"]        = 68,
+    ["Arcane Temple"]           = 66,
+    ["Blackened Lands"]         = 58,
+    ["Blackstone Dungeon"]      = 65,
+    ["Blackstone Keep"]         = 62,
+    ["Constructed underground"] = 2,
+    ["Dark Forest"]             = 1,
+    ["Deep Ocean"]              = 24,
+    ["Desert Ruins"]            = 38,
+    ["Dwarven city"]            = 18,
+    ["Forestal Council"]        = 44,
+    ["Frozen Bog"]              = 76,
+    ["Lake of Fire"]            = 56,
+    ["Natural underground"]     = 3,
+    ["Noble Bar"]               = 53,
+    ["Noble Chambers"]          = 51,
+    ["Rocky Shore"]             = 77,
+    ["Sylayan city"]            = 19,
+    ["Tainted Underground"]     = 35,
+    ["Tainted Water"]           = 39,
+    ["Underground Lake"]        = 36,
+    ["Vast Ocean"]              = 26,
+    ["Wetlands Village"]        = 64,
+    ["within a tent"]           = 69,
+    Academia                    = 42,
+    Acropolis                   = 33,
+    Beach                       = 5,
+    Blighted                    = 74,
+    bog                         = 73,
+    Catacombs                   = 63,
+    Church                      = 54,
+    Cliffs                      = 67,
+    Crags                       = 32,
+    Desert                      = 6,
+    Docks                       = 30,
+    Farmland                    = 41,
+    Forest                      = 4,
+    Freshwater                  = 22,
+    Garden                      = 21,
+    garrison                    = 71,
+    Grasslands                  = 7,
+    Graveyard                   = 46,
+    Hills                       = 9,
+    Jungle                      = 17,
+    Mountains                   = 14,
+    Nobility                    = 50,
+    Ocean                       = 20,
+    Path                        = 11,
+    Polar                       = 27,
+    Pond                        = 49,
+    pyramid                     = 72,
+    quarry                      = 70,
+    River                       = 10,
+    Road                        = 12,
+    Ruins                       = 37,
+    Scrublands                  = 78,
+    Sewer                       = 23,
+    Swamp                       = 15,
+    Temple                      = 57,
+    Tower                       = 79,
+    transportation              = 48,
+    Tundra                      = 16,
+    Underworld                  = 28,
+    Urban                       = 8,
+    Valley                      = 13,
+    Villa                       = 75,
+    Village                     = 47,
+    Village                     = 55,
+    Volcano                     = 59,
+    Warrens                     = 31,
+  }
+
+  mmp.waterenvs = {}
+  local waterids = { "River", "Ocean", "Deep Ocean", "Vast Ocean", "Underground Lake", "Tainted Water", "Lake of Fire" }
+  for i = 1, #waterids do mmp.waterenvs[mmp.envids[waterids[i]]] = true end
+
+  mmp.envidsr = {};
+  for name, id in pairs(mmp.envids) do mmp.envidsr[id] = name end
+end</script>
+						<eventHandlerList>
+							<string>mmp logged in</string>
 						</eventHandlerList>
 					</Script>
 				</Script>

--- a/mudlet-mapper.xml
+++ b/mudlet-mapper.xml
@@ -12218,7 +12218,6 @@ end</script>
     Valley                      = 13,
     Villa                       = 75,
     Village                     = 47,
-    Village                     = 55,
     Volcano                     = 59,
     Warrens                     = 31,
   }

--- a/mudlet-mapper.xml
+++ b/mudlet-mapper.xml
@@ -4616,6 +4616,7 @@ local function set(newid)
     setRoomEnv(rid, getRoomEnv(mmp.currentroom))
   end
   mmp.setExit(mmp.currentroom, rid, m)
+  clearRoomUserDataItem(newid, "hashonly")
   mmp.echo(string.format("Created new room (%d) at %dx, %dy, %dz.\n", rid, x, y, z))
   centerview(mmp.roomexists(mmp.currentroom) and mmp.currentroom or rid)
   if not mmp.roomexists(mmp.currentroom) then
@@ -6572,17 +6573,7 @@ function mmp.speedwalking(event, num)
   local num = tonumber(num) or tonumber(gmcp.Room.Info.num)
   
   if num == nil and gmcp.Room.Info.roomhash then
-    local hash = gmcp.Room.Info.roomhash
-    num = getRoomIDbyHash(hash)
-    
-    if num == -1 then
-      num = createRoomID()
-      addRoom(num)
-      setRoomIDbyHash(num, hash)
-      if mmp.debug then
-        mmp.echo(string.format("%s missing a room ID, created a new one for it: %d", hash, num))
-      end
-    end
+    num = mmp.roomidFromHash(gmcp.Room.Info.roomhash)
   end
   
   if num ~= mmp.currentroom then
@@ -9523,7 +9514,16 @@ end
 
 function mmp.roomexists(num)
   if not num then return false end
-  if roomExists then return roomExists(num) end
+  if roomExists then
+    -- in case we are in a hash-based game and the room ID got created to store a hash
+    -- and hasn't been created properly, say it doesn't exist
+    if getRoomUserData(num, "hashonly") == "true" then
+      mmp.echo("roomexists: returning false for "..num)
+      return false
+    else
+      return roomExists(num)
+    end
+  end
 
   local s,m = pcall(getRoomArea, tonumber(num))
   return (s and true or false)
@@ -9718,7 +9718,7 @@ end</script>
     for exit, leadsto in pairs(exits) do
       echo(
         string.format(
-          "  %s -&gt; %s (%d)%s%s\n",
+          "  %s -&gt; %s (%d)%s%s%s\n",
           exit,
           getRoomName(leadsto),
           leadsto,
@@ -9735,7 +9735,8 @@ end</script>
             " (weight: " ..
             exitweights[mmp.anytoshort(exit)] ..
             ")"
-          )
+          ),
+          (getRoomHashByID(num) and (" hash: ".. getRoomHashByID(leadsto)) or '')
         )
       )
     end
@@ -10313,6 +10314,8 @@ local function makeroom(oldid, newid, x, y, z)
   addRoom(newid)
   setRoomCoordinates(newid, x, y, z)
   setRoomArea(newid, getRoomArea(oldid))
+  -- in case we are in a hash-based game and the room ID already got created to store a hash, clear the flag
+  clearRoomUserDataItem(newid, "hashonly")
   local fgr, fgg, fgb = unpack(color_table.red)
   local bgr, bgg, bgb = unpack(color_table.blue)
   highlightRoom(newid, fgr, fgg, fgb, bgr, bgg, bgb, 1, 100, 100)
@@ -10391,13 +10394,17 @@ local function getshiftedcoords(original, ox, oy, oz)
   return x, y, z
 end
 
--- returns (and creates if needed) a room ID for a given hash
+-- returns a room ID for a given hash
+-- if a room doesn't exist, it'll create it in order to bind the hash to a certain createRoomID
+-- at the same time, it'll mark the userdata "hashonly" as "true" so mmp.roomExists won't say this room exists
+-- this preserves the same logic in the code as non-hash games
 function mmp.roomidFromHash(hash)
   local id = getRoomIDbyHash(hash)
   if id == -1 then 
     id = createRoomID()
     addRoom(id)
     setRoomIDbyHash(id, hash)
+    setRoomUserData(id, "hashonly", "true")
   end
   
   return id
@@ -10511,21 +10518,21 @@ function mmp.mappingNewroom(_, num)
             end
           else
             local function getshiftedcoords(direction, ox, oy, oz)
-              if direction == 'n' then
+              if direction == 'n' or direction == 'north' then
                 return ox, oy + 1, oz
-              elseif direction == 'e' then
-                return ox + 1, oy, oz
-              elseif direction == 's' then
+              elseif direction == 'e' or direction == 'east' then
+                return ox + 1, oy, oz  
+              elseif direction == 's' or direction == 'south' then
                 return ox, oy - 1, oz
-              elseif direction == 'w' then
+              elseif direction == 'w' or direction == 'west' then
                 return ox - 1, oy, oz
-              elseif direction == 'ne' then
+              elseif direction == 'ne' or direction == 'northeast' then
                 return ox + 1, oy + 1, oz
-              elseif direction == 'se' then
+              elseif direction == 'se' or direction == 'southeast' then
                 return ox + 1, oy - 1, oz
-              elseif direction == 'sw' then
+              elseif direction == 'sw' or direction == 'southwest' then
                 return ox - 1, oy - 1, oz
-              elseif direction == 'nw' then
+              elseif direction == 'nw' or direction == 'northwest' then
                 return ox - 1, oy + 1, oz
               else
                 error("getshiftedcoords: direction " .. direction .. " isn't supported yet.")

--- a/mudlet-mapper.xml
+++ b/mudlet-mapper.xml
@@ -6543,7 +6543,7 @@ function mmp.speedwalking(event, num)
       addRoom(num)
       setRoomIDbyHash(num, hash)
       if mmp.debug then
-        mmp.echo(f"{hash} missing a room ID, created a new one for it: {num}")
+        mmp.echo(string.format("%s missing a room ID, created a new one for it: %d", hash, num))
       end
     end
   end
@@ -10263,6 +10263,8 @@ end</script>
 					<script>--mmp.mappingNewroom
 
 local function makeroom(oldid, newid, x, y, z)
+  assert(oldid, "makeroom: need the ID of the original room")
+  assert(newid, "makeroom: need the ID of the room to create")
   assert(x and y and z, "makeroom: need all 3 coordinates")
   addRoom(newid)
   setRoomCoordinates(newid, x, y, z)
@@ -10345,6 +10347,16 @@ local function getshiftedcoords(original, ox, oy, oz)
   return x, y, z
 end
 
+-- returns (and creates if needed) a room ID for a given hash
+function mmp.obtainHash(hash)
+  local id = getRoomIDbyHash(hash)
+  if id == -1 then 
+    id = createRoomID()
+    addRoom(id)
+    setRoomIDbyHash(id, hash)
+  end
+end
+
 function mmp.mappingNewroom(_, num)
   local s, m =
     xpcall(
@@ -10367,6 +10379,9 @@ function mmp.mappingNewroom(_, num)
         local getRoomName, getRoomCoordinates, getRoomsByPosition =
           getRoomName, getRoomCoordinates, getRoomsByPosition
         local num = tonumber(num) or tonumber(gmcp.Room.Info.num)
+        if not num and gmcp.Room.Info.roomhash then
+          num = mmp.obtainHash(gmcp.Room.Info.roomhash)
+        end
         local currentexits = gmcp.Room.Info.exits
         local s = ""
         if not mmp.roomexists(num) then
@@ -10374,6 +10389,12 @@ function mmp.mappingNewroom(_, num)
           -- wilderness and non-wilderness rooms require different methods of calculating relative coordinates
           if not inwilderness() then
             for exit, id in pairs(currentexits) do
+              if gmcp.Room.Info.roomhash then
+                -- in a hash-based game, the 'id' is actually a hash, not an id
+                -- turn it into a proper id:
+                id = mmp.obtainHash(id)
+              end
+              
               if mmp.roomexists(id) then
                 s = makeroom(id, num, getshiftedcoords(exit, getRoomCoordinates(id)))
               end
@@ -10568,6 +10589,7 @@ function mmp.mappingNewroom(_, num)
         end
         if #s &gt; 0 then
           mmp.echo(s)
+          mmp.debug(tostring(mmp.currentroom))
           centerview(mmp.currentroom)
         end
       end,

--- a/mudlet-mapper.xml
+++ b/mudlet-mapper.xml
@@ -4411,7 +4411,7 @@ mmp.settings:setOption(matches[3], val)</script>
 				<packageName></packageName>
 				<regex>^area list$</regex>
 			</Alias>
-			<AliasGroup isActive="no" isFolder="yes">
+			<AliasGroup isActive="yes" isFolder="yes">
 				<name>mm Mapping</name>
 				<script></script>
 				<command></command>
@@ -6533,9 +6533,25 @@ local oldnum
 
 function mmp.speedwalking(event, num)
   local num = tonumber(num) or tonumber(gmcp.Room.Info.num)
+  
+  if num == nil and gmcp.Room.Info.roomhash then
+    local hash = gmcp.Room.Info.roomhash
+    num = getRoomIDbyHash(hash)
+    
+    if num == -1 then
+      num = createRoomID()
+      addRoom(num)
+      setRoomIDbyHash(num, hash)
+      if mmp.debug then
+        mmp.echo(f"{hash} missing a room ID, created a new one for it: {num}")
+      end
+    end
+  end
+  
   if num ~= mmp.currentroom then
     mmp.previousroom = mmp.currentroom
   end
+  
   mmp.currentroom = num
   mmp.currentroomname = getRoomName(num)
   -- Try to track if we're flying or not, for Imperian wings
@@ -9640,7 +9656,7 @@ end</script>
     -- generate a report
     mmp.echo(
       string.format(
-        "Room: %s #: %d area: %s (%d)", name, num, tostring(mmp.areatabler[areanum]), areanum
+        "Room: %s #: %d%s area: %s (%d)", name, num, (getRoomHashByID(num) and (" hash: ".. getRoomHashByID(num)) or ''), tostring(mmp.areatabler[areanum]), areanum
       )
     )
     mmp.echo(

--- a/mudlet-mapper.xml
+++ b/mudlet-mapper.xml
@@ -4545,7 +4545,7 @@ mmp.settings:setOption(matches[3], val)</script>
 				<packageName></packageName>
 				<regex>^area list$</regex>
 			</Alias>
-			<AliasGroup isActive="yes" isFolder="yes">
+			<AliasGroup isActive="no" isFolder="yes">
 				<name>mm Mapping</name>
 				<script></script>
 				<command></command>

--- a/mudlet-mapper.xml
+++ b/mudlet-mapper.xml
@@ -10379,7 +10379,6 @@ end
     if gmcp.Room.Info.num then
       centerview(gmcp.Room.Info.num)
     elseif gmcp.Room.Info.roomhash then
-    print(tostring(mmp.roomidFromHash(gmcp.Room.Info.roomhash)))
       centerview(mmp.roomidFromHash(gmcp.Room.Info.roomhash))
     end
   end


### PR DESCRIPTION
Add support for games that operate on hashes. The basic premise is to pre-create rooms that don't exist yet to assign them a hash, but still consider them "non-existent" for all intents and purposes to keep the existing logic happy.