### PR TITLE
FIX: add missing Z coordinate to createMapLabel()

### DIFF
--- a/mudlet-mapper.xml
+++ b/mudlet-mapper.xml
@@ -9026,11 +9026,11 @@ function mmp.roomLabel(input)
     mmp.echo("We don't know where we are to make a label here.")
     return
   end
-  local x, y = getRoomCoordinates(room)
+  local x, y, z = getRoomCoordinates(room)
   local f1, f2, f3 = unpack(color_table[fg])
   local b1, b2, b3 = unpack(color_table[bg])
   -- finally: do it :)
-  local lid = createMapLabel(getRoomArea(room), message, x, y, f1, f2, f3, b1, b2, b3)
+  local lid = createMapLabel(getRoomArea(room), message, x, y, z, f1, f2, f3, b1, b2, b3)
   mmp.echo(
     string.format(
       "Created new label #%d '%s' in %s.", lid, message, getRoomAreaName(getRoomArea(room))


### PR DESCRIPTION
createMapLabel() throws error due to missing arguments, add Z coordinate to createMapLabel() in 'room label' alias