### PR TITLE
Use a temptimer to avoid profile wipe bug

### DIFF
--- a/mudlet-mapper.xml
+++ b/mudlet-mapper.xml
@@ -12537,7 +12537,7 @@ function mmp.installMapperScript()
   local path = getModulePath("mudlet-mapper")
   if not path then
     uninstallPackage("mudlet-mapper")
-    tempTimer(0, [[installPackage(mmp.downloadedscript)]])
+    tempTimer(1, [[installPackage(mmp.downloadedscript)]])
   else
     reloadModule("mudlet-mapper")
   end

--- a/mudlet-mapper.xml
+++ b/mudlet-mapper.xml
@@ -12537,7 +12537,7 @@ function mmp.installMapperScript()
   local path = getModulePath("mudlet-mapper")
   if not path then
     uninstallPackage("mudlet-mapper")
-    installPackage(mmp.downloadedscript)
+    tempTimer(0, [[installPackage(mmp.downloadedscript)]])
   else
     reloadModule("mudlet-mapper")
   end


### PR DESCRIPTION
I have had reports from many people that the automatic updates to the mudlet-mapper are wiping their profiles. After doing some testing I believe this is the same issue that was wiping the svof modules during updates, but happening to the profile xml. They were able to consistently repeat the issue on current release Mudlet but the PTB was fixed.

Until we get the fix in a release, the temp fix for svof was using a 0 second temptimer to force the execution of the install to happen after the save from the uninstall. I believe implementing this fix will also resolve the issue here for now.