### PR TITLE
Fix goto feature changing destination room

### DIFF
--- a/mudlet-mapper.xml
+++ b/mudlet-mapper.xml
@@ -7088,7 +7088,7 @@ function mmp.gotoFeature(partialFeatureName, dashtype)
     return
   end
   raiseEvent("mmp clear externals")
-  mmp.gotoRoom(closestFeature, dashtype, "area")
+  mmp.gotoRoom(closestFeature, dashtype, "room")
 end</script>
 				<eventHandlerList>
 					<string>RoomNum</string>


### PR DESCRIPTION
If an outside room is encountered, goto feature may change the destination room due to being classified as "area" goto type. Setting that to "room" fixes that.