### PR TITLE
added line break for mapper update #7361

### DIFF
--- a/mudlet-mapper.xml
+++ b/mudlet-mapper.xml
@@ -12327,7 +12327,7 @@ end</script>
     mmp.echon("------------------[ Mapper Script Update ]------------------")
     mmp.echon(" The mapper script was updated from &lt;orange&gt;"..tostring(mmp.version).."&lt;reset&gt; -&gt; &lt;green&gt;"..tostring(mmp.newmapperversion).."&lt;reset&gt;!")
     mmp.echon("")
-    cechoLink(" Would you like to install the update? &lt;u&gt;&lt;ForestGreen&gt;Click here if so&lt;/u&gt;&lt;reset&gt;.", "mmp.downloadmapperscript()", "Changelog for the latest ("..tostring(mmp.version).." -&gt; "..tostring(mmp.newmapperversion)..") update:\n"..changelog, true)
+    cechoLink(" Would you like to install the update? &lt;u&gt;&lt;ForestGreen&gt;\n Click here if so&lt;/u&gt;&lt;reset&gt;.", "mmp.downloadmapperscript()", "Changelog for the latest ("..tostring(mmp.version).." -&gt; "..tostring(mmp.newmapperversion)..") update:\n"..changelog, true)
     echo("\n\n")
 
   elseif filename == mmp.crowdchangelogfile then   -- changelog for the crowdmap


### PR DESCRIPTION
An [issue](https://github.com/Mudlet/Mudlet/issues/7361) was raised in the mudlet repo wanting a line break so that "click me if so..." is added to the next line, these are the necessary changes i made.
(added a line break "\n" between the the the line as shown below).

`cechoLink(" Would you like to install the update? &lt;u&gt;&lt;ForestGreen&gt;\n Click here if so&lt;/u&gt;&lt;reset&gt;.", "mmp.downloadmapperscript()", "Changelog for the latest ("..tostring(mmp.version).." -&gt; "..tostring(mmp.newmapperversion)..") update:\n"..changelog, true)
    echo("\n\n")`