### PR TITLE
raise event when ire-mapping-script has finished loading

### DIFF
--- a/mudlet-mapper.xml
+++ b/mudlet-mapper.xml
@@ -6092,6 +6092,7 @@ function mmp.startup()
     "Clicky clicky to read up on what's this about"
   )
   echo(")\n")
+  raiseEvent("mapperScriptLoaded", "ire-mapping-script")
 end</script>
 				<eventHandlerList />
 			</Script>


### PR DESCRIPTION
As per https://github.com/Mudlet/Mudlet/issues/7533, raise an event to notify scripters that ire-mapping-script has finished loading

i.e. `raiseEvent("mapperScriptLoaded", "ire-mapping-script")`